### PR TITLE
52 매칭목록

### DIFF
--- a/src/main/java/uni/backend/controller/MatchingController.java
+++ b/src/main/java/uni/backend/controller/MatchingController.java
@@ -7,11 +7,15 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.bind.annotation.*;
 import uni.backend.domain.Matching;
 import uni.backend.domain.User;
+import uni.backend.domain.dto.MatchingListResponse;
 import uni.backend.domain.dto.MatchingRequest;
 import uni.backend.domain.dto.MatchingResponse;
 import uni.backend.service.MatchingService;
 import uni.backend.service.UserService;
+
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/match")
@@ -92,5 +96,19 @@ public class MatchingController {
         }
 
         return matchingResponse;
+    }
+
+    @GetMapping("/list/requester/{requesterId}")
+    public List<MatchingListResponse> getMatchingListByRequester(@PathVariable Integer requesterId) {
+        return matchingService.getMatchingListByRequesterId(requesterId).stream()
+                .map(MatchingListResponse::fromMatching)
+                .collect(Collectors.toList());
+    }
+
+    @GetMapping("/list/receiver/{receiverId}")
+    public List<MatchingListResponse> getMatchingListByReceiver(@PathVariable Integer receiverId) {
+        return matchingService.getMatchingListByReceiverId(receiverId).stream()
+                .map(MatchingListResponse::fromMatching)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/uni/backend/domain/dto/MatchingListResponse.java
+++ b/src/main/java/uni/backend/domain/dto/MatchingListResponse.java
@@ -1,0 +1,28 @@
+package uni.backend.domain.dto;
+
+import lombok.*;
+import uni.backend.domain.Matching;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MatchingListResponse {
+    private Integer matchingId;
+    private Integer requesterId;
+    private Integer receiverId;
+    private String status;
+    private LocalDateTime createdAt;
+
+    public static MatchingListResponse fromMatching(Matching matching) {
+        return MatchingListResponse.builder()
+                .matchingId(matching.getRequestId())
+                .requesterId(matching.getRequester().getUserId())
+                .receiverId(matching.getReceiver().getUserId())
+                .status(matching.getStatus().name())
+                .createdAt(matching.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/uni/backend/repository/MatchingRepository.java
+++ b/src/main/java/uni/backend/repository/MatchingRepository.java
@@ -3,5 +3,9 @@ package uni.backend.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import uni.backend.domain.Matching;
 
+import java.util.List;
+
 public interface MatchingRepository extends JpaRepository<Matching, Integer> {
+    List<Matching> findByRequester_UserId(Integer requesterId);
+    List<Matching> findByReceiver_UserId(Integer receiverId);
 }

--- a/src/main/java/uni/backend/service/MatchingService.java
+++ b/src/main/java/uni/backend/service/MatchingService.java
@@ -8,6 +8,7 @@ import uni.backend.domain.User;
 import uni.backend.domain.dto.MatchingResponse;
 import uni.backend.repository.MatchingRepository;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -35,5 +36,13 @@ public class MatchingService {
             matchingRepository.save(request);
         });
         return requestOpt;
+    }
+
+    public List<Matching> getMatchingListByRequesterId(Integer requesterId) {
+        return matchingRepository.findByRequester_UserId(requesterId);
+    }
+
+    public List<Matching> getMatchingListByReceiverId(Integer receiverId) {
+        return matchingRepository.findByReceiver_UserId(receiverId);
     }
 }

--- a/src/test/java/uni/backend/controller/MatchingControllerTest.java
+++ b/src/test/java/uni/backend/controller/MatchingControllerTest.java
@@ -1,0 +1,106 @@
+package uni.backend.controller;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import uni.backend.domain.Matching;
+import uni.backend.domain.User;
+import uni.backend.service.MatchingService;
+import uni.backend.service.UserService;
+import uni.backend.controller.MatchingController;
+
+@WebMvcTest(MatchingController.class)
+class MatchingControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MatchingService matchingService;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private SimpMessagingTemplate messagingTemplate;
+
+    private Matching matching1;
+    private Matching matching2;
+
+    @BeforeEach
+    void setUp() {
+        User requester = new User();
+        requester.setUserId(1);
+
+        User receiver = new User();
+        receiver.setUserId(2);
+
+        matching1 = Matching.builder()
+                .requestId(1)
+                .requester(requester)
+                .receiver(receiver)
+                .status(Matching.Status.PENDING)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        matching2 = Matching.builder()
+                .requestId(2)
+                .requester(requester)
+                .receiver(receiver)
+                .status(Matching.Status.ACCEPTED)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    @Test
+    @WithMockUser
+    void 요청자_ID로_매칭_목록_조회() throws Exception {
+        // given
+        when(matchingService.getMatchingListByRequesterId(1)).thenReturn(Arrays.asList(matching1, matching2));
+
+        // when
+        mockMvc.perform(get("/api/match/list/requester/1"))
+
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].matchingId", is(1)))
+                .andExpect(jsonPath("$[0].requesterId", is(1)))
+                .andExpect(jsonPath("$[0].status", is("PENDING")));
+    }
+
+    @Test
+    @WithMockUser
+    void 수신자_ID로_매칭_목록_조회() throws Exception {
+        // given
+        when(matchingService.getMatchingListByReceiverId(2)).thenReturn(Arrays.asList(matching1, matching2));
+
+        // when
+        mockMvc.perform(get("/api/match/list/receiver/2"))
+
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[1].matchingId", is(2)))
+                .andExpect(jsonPath("$[1].receiverId", is(2)))
+                .andExpect(jsonPath("$[1].status", is("ACCEPTED")));
+    }
+}

--- a/src/test/java/uni/backend/service/MatchingServiceTest.java
+++ b/src/test/java/uni/backend/service/MatchingServiceTest.java
@@ -11,6 +11,8 @@ import uni.backend.domain.dto.MatchingResponse;
 import uni.backend.repository.MatchingRepository;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -114,5 +116,77 @@ class MatchingServiceTest {
         // then
         assertEquals(Optional.empty(), resultOpt);
         verify(matchingRepository, never()).save(any(Matching.class));
+    }
+
+    @Test
+    void 요청자_ID로_매칭_목록_조회() {
+        // given
+        int requesterId = 1;
+        User requester = new User();
+        requester.setUserId(requesterId);
+
+        Matching matching1 = Matching.builder()
+                .requestId(1)
+                .requester(requester)
+                .receiver(new User())
+                .status(Matching.Status.PENDING)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        Matching matching2 = Matching.builder()
+                .requestId(2)
+                .requester(requester)
+                .receiver(new User())
+                .status(Matching.Status.ACCEPTED)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        when(matchingRepository.findByRequester_UserId(requesterId))
+                .thenReturn(Arrays.asList(matching1, matching2));
+
+        // when
+        List<Matching> result = matchingService.getMatchingListByRequesterId(requesterId);
+
+        // then
+        assertEquals(2, result.size());
+        assertEquals(requesterId, result.get(0).getRequester().getUserId());
+        assertEquals(requesterId, result.get(1).getRequester().getUserId());
+        verify(matchingRepository, times(1)).findByRequester_UserId(requesterId);
+    }
+
+    @Test
+    void 수신자_ID로_매칭_목록_조회() {
+        // given
+        int receiverId = 2;
+        User receiver = new User();
+        receiver.setUserId(receiverId);
+
+        Matching matching1 = Matching.builder()
+                .requestId(1)
+                .requester(new User())
+                .receiver(receiver)
+                .status(Matching.Status.PENDING)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        Matching matching2 = Matching.builder()
+                .requestId(2)
+                .requester(new User())
+                .receiver(receiver)
+                .status(Matching.Status.ACCEPTED)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        when(matchingRepository.findByReceiver_UserId(receiverId))
+                .thenReturn(Arrays.asList(matching1, matching2));
+
+        // when
+        List<Matching> result = matchingService.getMatchingListByReceiverId(receiverId);
+
+        // then
+        assertEquals(2, result.size());
+        assertEquals(receiverId, result.get(0).getReceiver().getUserId());
+        assertEquals(receiverId, result.get(1).getReceiver().getUserId());
+        verify(matchingRepository, times(1)).findByReceiver_UserId(receiverId);
     }
 }


### PR DESCRIPTION
feat: 매칭 목록 요청 응답을 위한 `MatchingListResponse` DTO 추가

- 매칭 목록 요청 응답 데이터를 구조화하기 위한 `MatchingListResponse` DTO를 생성했습니다.
- `matchingId`, `requesterId`, `receiverId`, `status`, `createdAt` 필드를 포함하여
  JSON 응답 구조를 지원합니다.

feat:`MatchingRepository`에 `User` ID로 매칭 검색하는 메서드 추가

- `requesterId`와 `receiverId`를 통해 매칭을 검색하는 
  `findByRequester_UserId`, `findByReceiver_UserId` 메서드를 추가했습니다.

feat: `MatchingService`에 요청자 및 수신자 ID로 매칭 목록 조회 메서드 추가

- `MatchingService`에 `getMatchingListByRequesterId`와 `getMatchingListByReceiverId`
  메서드를 추가하여 각각 `requesterId`와 `receiverId`에 따른 매칭 목록을 
  조회하도록 구현했습니다.

feat: `MatchingController`에 매칭 리스트 조회 엔드포인트 추가

- 요청자 ID(`requesterId`)와 수신자 ID(`receiverId`)로 매칭 목록을 조회할 수 있는 
  두 개의 GET 엔드포인트를 추가했습니다.
  
  - `getMatchingListByRequester`: `/list/requester/{requesterId}` 경로를 통해 
    해당 요청자 ID와 일치하는 매칭 목록을 조회합니다.
  - `getMatchingListByReceiver`: `/list/receiver/{receiverId}` 경로를 통해 
    해당 수신자 ID와 일치하는 매칭 목록을 조회합니다.

- 각 엔드포인트는 `MatchingService`에서 조회된 매칭 리스트를 
  `MatchingListResponse` DTO로 변환하여 응답합니다.

test: `MatchingService` 테스트에 요청자 및 수신자 ID로 매칭 목록 조회 테스트 추가

- `MatchingService`에 추가된 `getMatchingListByRequesterId`, `getMatchingListByReceiverId` 메서드에 대한 테스트 코드 추가
- 요청자 ID(`requesterId`)와 수신자 ID(`receiverId`)로 매칭 목록을 올바르게 조회하는지 검증
- given-when-then 구조로 테스트 코드 작성하여 가독성 개선

test: `MatchingController`에 매칭 목록 조회 테스트 추가

- `MatchingController`에 요청자 ID 및 수신자 ID로 매칭 목록을 조회하는 엔드포인트 테스트 추가
- `MockMvc`와 `@WithMockUser`를 사용하여 인증 문제 해결 및 컨트롤러 응답 검증
- given-when-then 구조로 테스트 코드 작성하여 테스트 단계별 가독성 개선
- 예상 응답의 JSON 구조 및 상태 코드 검증을 통해 각 엔드포인트의 응답 정확성 확인