### PR TITLE
55 매칭요청 리팩토링

### DIFF
--- a/src/main/java/uni/backend/controller/MatchingController.java
+++ b/src/main/java/uni/backend/controller/MatchingController.java
@@ -1,6 +1,8 @@
 package uni.backend.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -29,7 +31,8 @@ public class MatchingController {
     private SimpMessagingTemplate messagingTemplate;
 
     @PostMapping("/request")
-    public MatchingCreateResponse createMatchRequest(@RequestBody MatchingCreateRequest matchingCreateRequest) {
+    public ResponseEntity<MatchingCreateResponse> createMatchRequest(@RequestBody MatchingCreateRequest matchingCreateRequest) {
+
         User requester = userService.findById(matchingCreateRequest.getRequesterId());
         User receiver = userService.findById(matchingCreateRequest.getReceiverId());
 
@@ -41,24 +44,33 @@ public class MatchingController {
 
         Matching savedRequest = matchingService.createRequest(request, requester, receiver);
 
+        MatchingCreateResponse response = MatchingCreateResponse.from(savedRequest);
+
         messagingTemplate.convertAndSend("/sub/match-request/" + matchingCreateRequest.getReceiverId(), "매칭 요청이 도착했습니다.");
 
-        return MatchingCreateResponse.from(savedRequest);
+        return ResponseEntity.ok(response);
     }
 
+
     @PostMapping("/respond")
-    public MatchingUpdateResponse respondToMatchRequest(@RequestBody MatchingUpdateRequest matchingUpdateRequest) {
+    public ResponseEntity<String> respondToMatchRequest(@RequestBody MatchingUpdateRequest matchingUpdateRequest) {
         Optional<Matching> requestOpt = matchingService.updateRequestStatus(matchingUpdateRequest);
 
         if (requestOpt.isPresent()) {
             Matching request = requestOpt.get();
-            String responseMessage = matchingUpdateRequest.isAccepted() ? "매칭 요청이 수락되었습니다." : "매칭 요청이 거절되었습니다.";
+
+            String responseMessage = matchingUpdateRequest.isAccepted()
+                    ? "매칭 요청이 수락되었습니다."
+                    : "매칭 요청이 거절되었습니다.";
+
             messagingTemplate.convertAndSend("/sub/match-response/" + request.getRequester().getUserId(), responseMessage);
 
-            return MatchingUpdateResponse.from(request);
+            return ResponseEntity.ok("응답 처리 완료");
         }
-        throw new IllegalArgumentException("요청을 찾을 수 없습니다.");
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body("요청을 찾을 수 없습니다.");
     }
+
 
     @MessageMapping("/match/request")
     @SendTo("/sub/match/request")

--- a/src/main/java/uni/backend/domain/Matching.java
+++ b/src/main/java/uni/backend/domain/Matching.java
@@ -16,8 +16,8 @@ public class Matching {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "request_id")
-    private Integer requestId;
+    @Column(name = "matching_id")
+    private Integer matchingId;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -34,7 +34,7 @@ public class Matching {
     @JoinColumn(name = "receiver_id", nullable = false)
     private User receiver;
 
-    @OneToMany(mappedBy = "request", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "matching", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<MatchingJoin> matchingJoins;
 
     @PrePersist

--- a/src/main/java/uni/backend/domain/MatchingJoin.java
+++ b/src/main/java/uni/backend/domain/MatchingJoin.java
@@ -19,6 +19,6 @@ public class MatchingJoin {
 
     @Id
     @ManyToOne
-    @JoinColumn(name = "request_id", nullable = false)
-    private Matching request;
+    @JoinColumn(name = "matching_id", nullable = false)
+    private Matching matching;
 }

--- a/src/main/java/uni/backend/domain/MatchingJoinId.java
+++ b/src/main/java/uni/backend/domain/MatchingJoinId.java
@@ -6,5 +6,5 @@ import java.io.Serializable;
 @EqualsAndHashCode
 public class MatchingJoinId implements Serializable {
     private Integer user;
-    private Integer request;
+    private Integer matching;
 }

--- a/src/main/java/uni/backend/domain/dto/MatchingCreateRequest.java
+++ b/src/main/java/uni/backend/domain/dto/MatchingCreateRequest.java
@@ -7,8 +7,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class MatchingRequest {
-    private Integer requestId;
+public class MatchingCreateRequest {
     private Integer requesterId;
     private Integer receiverId;
 }

--- a/src/main/java/uni/backend/domain/dto/MatchingCreateResponse.java
+++ b/src/main/java/uni/backend/domain/dto/MatchingCreateResponse.java
@@ -1,0 +1,21 @@
+package uni.backend.domain.dto;
+
+import lombok.*;
+import uni.backend.domain.Matching;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MatchingCreateResponse {
+    private Integer requestId;
+    private String status;
+
+    public static MatchingCreateResponse from(Matching matching) {
+        return MatchingCreateResponse.builder()
+                .requestId(matching.getRequestId())
+                .status(matching.getStatus().name())
+                .build();
+    }
+}

--- a/src/main/java/uni/backend/domain/dto/MatchingCreateResponse.java
+++ b/src/main/java/uni/backend/domain/dto/MatchingCreateResponse.java
@@ -3,19 +3,27 @@ package uni.backend.domain.dto;
 import lombok.*;
 import uni.backend.domain.Matching;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class MatchingCreateResponse {
-    private Integer requestId;
+    private Integer matchingId;
+    private Integer requesterId;
+    private Integer receiverId;
     private String status;
+    private LocalDateTime createdAt;
 
     public static MatchingCreateResponse from(Matching matching) {
         return MatchingCreateResponse.builder()
-                .requestId(matching.getRequestId())
+                .matchingId(matching.getMatchingId())
+                .requesterId(matching.getRequester().getUserId())
+                .receiverId(matching.getReceiver().getUserId())
                 .status(matching.getStatus().name())
+                .createdAt(matching.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/uni/backend/domain/dto/MatchingListResponse.java
+++ b/src/main/java/uni/backend/domain/dto/MatchingListResponse.java
@@ -18,7 +18,7 @@ public class MatchingListResponse {
 
     public static MatchingListResponse fromMatching(Matching matching) {
         return MatchingListResponse.builder()
-                .matchingId(matching.getRequestId())
+                .matchingId(matching.getMatchingId())
                 .requesterId(matching.getRequester().getUserId())
                 .receiverId(matching.getReceiver().getUserId())
                 .status(matching.getStatus().name())

--- a/src/main/java/uni/backend/domain/dto/MatchingUpdateRequest.java
+++ b/src/main/java/uni/backend/domain/dto/MatchingUpdateRequest.java
@@ -8,6 +8,6 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class MatchingUpdateRequest {
-    private Integer requestId;
+    private Integer matchingId;
     private boolean accepted;
 }

--- a/src/main/java/uni/backend/domain/dto/MatchingUpdateRequest.java
+++ b/src/main/java/uni/backend/domain/dto/MatchingUpdateRequest.java
@@ -7,7 +7,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class MatchingResponse {
+public class MatchingUpdateRequest {
     private Integer requestId;
     private boolean accepted;
 }

--- a/src/main/java/uni/backend/domain/dto/MatchingUpdateResponse.java
+++ b/src/main/java/uni/backend/domain/dto/MatchingUpdateResponse.java
@@ -1,0 +1,21 @@
+package uni.backend.domain.dto;
+
+import lombok.*;
+import uni.backend.domain.Matching;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MatchingUpdateResponse {
+    private Integer requestId;
+    private String status;
+
+    public static MatchingUpdateResponse from(Matching matching) {
+        return MatchingUpdateResponse.builder()
+                .requestId(matching.getRequestId())
+                .status(matching.getStatus().name())
+                .build();
+    }
+}

--- a/src/main/java/uni/backend/domain/dto/MatchingUpdateResponse.java
+++ b/src/main/java/uni/backend/domain/dto/MatchingUpdateResponse.java
@@ -9,12 +9,12 @@ import uni.backend.domain.Matching;
 @AllArgsConstructor
 @Builder
 public class MatchingUpdateResponse {
-    private Integer requestId;
+    private Integer matchingId;
     private String status;
 
     public static MatchingUpdateResponse from(Matching matching) {
         return MatchingUpdateResponse.builder()
-                .requestId(matching.getRequestId())
+                .matchingId(matching.getMatchingId())
                 .status(matching.getStatus().name())
                 .build();
     }

--- a/src/main/java/uni/backend/service/MatchingService.java
+++ b/src/main/java/uni/backend/service/MatchingService.java
@@ -30,7 +30,7 @@ public class MatchingService {
 
     @Transactional
     public Optional<Matching> updateRequestStatus(MatchingUpdateRequest matchingUpdateRequest) {
-        Optional<Matching> requestOpt = matchingRepository.findById(matchingUpdateRequest.getRequestId());
+        Optional<Matching> requestOpt = matchingRepository.findById(matchingUpdateRequest.getMatchingId());
         requestOpt.ifPresent(request -> {
             request.setStatus(matchingUpdateRequest.isAccepted() ? Matching.Status.ACCEPTED : Matching.Status.REJECTED);
             matchingRepository.save(request);

--- a/src/main/java/uni/backend/service/MatchingService.java
+++ b/src/main/java/uni/backend/service/MatchingService.java
@@ -5,7 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uni.backend.domain.Matching;
 import uni.backend.domain.User;
-import uni.backend.domain.dto.MatchingResponse;
+import uni.backend.domain.dto.MatchingUpdateRequest;
 import uni.backend.repository.MatchingRepository;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -29,10 +29,10 @@ public class MatchingService {
     }
 
     @Transactional
-    public Optional<Matching> updateRequestStatus(MatchingResponse matchingResponse) {
-        Optional<Matching> requestOpt = matchingRepository.findById(matchingResponse.getRequestId());
+    public Optional<Matching> updateRequestStatus(MatchingUpdateRequest matchingUpdateRequest) {
+        Optional<Matching> requestOpt = matchingRepository.findById(matchingUpdateRequest.getRequestId());
         requestOpt.ifPresent(request -> {
-            request.setStatus(matchingResponse.isAccepted() ? Matching.Status.ACCEPTED : Matching.Status.REJECTED);
+            request.setStatus(matchingUpdateRequest.isAccepted() ? Matching.Status.ACCEPTED : Matching.Status.REJECTED);
             matchingRepository.save(request);
         });
         return requestOpt;

--- a/src/test/java/uni/backend/controller/MatchingControllerTest.java
+++ b/src/test/java/uni/backend/controller/MatchingControllerTest.java
@@ -54,7 +54,7 @@ class MatchingControllerTest {
         receiver.setUserId(2);
 
         matching1 = Matching.builder()
-                .requestId(1)
+                .matchingId(1)
                 .requester(requester)
                 .receiver(receiver)
                 .status(Matching.Status.PENDING)
@@ -62,7 +62,7 @@ class MatchingControllerTest {
                 .build();
 
         matching2 = Matching.builder()
-                .requestId(2)
+                .matchingId(2)
                 .requester(requester)
                 .receiver(receiver)
                 .status(Matching.Status.ACCEPTED)

--- a/src/test/java/uni/backend/service/MatchingServiceTest.java
+++ b/src/test/java/uni/backend/service/MatchingServiceTest.java
@@ -7,7 +7,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import uni.backend.domain.Matching;
 import uni.backend.domain.User;
-import uni.backend.domain.dto.MatchingResponse;
+import uni.backend.domain.dto.MatchingUpdateRequest;
 import uni.backend.repository.MatchingRepository;
 
 import java.time.LocalDateTime;
@@ -65,7 +65,7 @@ class MatchingServiceTest {
         Matching matching = new Matching();
         matching.setStatus(Matching.Status.PENDING);
 
-        MatchingResponse response = new MatchingResponse();
+        MatchingUpdateRequest response = new MatchingUpdateRequest();
         response.setRequestId(requestId);
         response.setAccepted(true);
 
@@ -86,7 +86,7 @@ class MatchingServiceTest {
         Matching matching = new Matching();
         matching.setStatus(Matching.Status.PENDING);
 
-        MatchingResponse response = new MatchingResponse();
+        MatchingUpdateRequest response = new MatchingUpdateRequest();
         response.setRequestId(requestId);
         response.setAccepted(false);
 
@@ -104,7 +104,7 @@ class MatchingServiceTest {
     void 매칭_요청_찾을_수_없음() {
         // given
         int requestId = 3;
-        MatchingResponse response = new MatchingResponse();
+        MatchingUpdateRequest response = new MatchingUpdateRequest();
         response.setRequestId(requestId);
         response.setAccepted(true);
 

--- a/src/test/java/uni/backend/service/MatchingServiceTest.java
+++ b/src/test/java/uni/backend/service/MatchingServiceTest.java
@@ -61,15 +61,15 @@ class MatchingServiceTest {
     @Test
     void 매칭_요청_수락() {
         // given
-        int requestId = 1;
+        int matchingId = 1;
         Matching matching = new Matching();
         matching.setStatus(Matching.Status.PENDING);
 
         MatchingUpdateRequest response = new MatchingUpdateRequest();
-        response.setRequestId(requestId);
+        response.setMatchingId(matchingId);
         response.setAccepted(true);
 
-        when(matchingRepository.findById(requestId)).thenReturn(Optional.of(matching));
+        when(matchingRepository.findById(matchingId)).thenReturn(Optional.of(matching));
 
         // when
         Optional<Matching> resultOpt = matchingService.updateRequestStatus(response);
@@ -82,15 +82,15 @@ class MatchingServiceTest {
     @Test
     void 매칭_요청_거절() {
         // given
-        int requestId = 2;
+        int matchingId = 2;
         Matching matching = new Matching();
         matching.setStatus(Matching.Status.PENDING);
 
         MatchingUpdateRequest response = new MatchingUpdateRequest();
-        response.setRequestId(requestId);
+        response.setMatchingId(matchingId);
         response.setAccepted(false);
 
-        when(matchingRepository.findById(requestId)).thenReturn(Optional.of(matching));
+        when(matchingRepository.findById(matchingId)).thenReturn(Optional.of(matching));
 
         // when
         Optional<Matching> resultOpt = matchingService.updateRequestStatus(response);
@@ -103,12 +103,12 @@ class MatchingServiceTest {
     @Test
     void 매칭_요청_찾을_수_없음() {
         // given
-        int requestId = 3;
+        int matchingId = 3;
         MatchingUpdateRequest response = new MatchingUpdateRequest();
-        response.setRequestId(requestId);
+        response.setMatchingId(matchingId);
         response.setAccepted(true);
 
-        when(matchingRepository.findById(requestId)).thenReturn(Optional.empty());
+        when(matchingRepository.findById(matchingId)).thenReturn(Optional.empty());
 
         // when
         Optional<Matching> resultOpt = matchingService.updateRequestStatus(response);
@@ -126,7 +126,7 @@ class MatchingServiceTest {
         requester.setUserId(requesterId);
 
         Matching matching1 = Matching.builder()
-                .requestId(1)
+                .matchingId(1)
                 .requester(requester)
                 .receiver(new User())
                 .status(Matching.Status.PENDING)
@@ -134,7 +134,7 @@ class MatchingServiceTest {
                 .build();
 
         Matching matching2 = Matching.builder()
-                .requestId(2)
+                .matchingId(2)
                 .requester(requester)
                 .receiver(new User())
                 .status(Matching.Status.ACCEPTED)
@@ -162,7 +162,7 @@ class MatchingServiceTest {
         receiver.setUserId(receiverId);
 
         Matching matching1 = Matching.builder()
-                .requestId(1)
+                .matchingId(1)
                 .requester(new User())
                 .receiver(receiver)
                 .status(Matching.Status.PENDING)
@@ -170,7 +170,7 @@ class MatchingServiceTest {
                 .build();
 
         Matching matching2 = Matching.builder()
-                .requestId(2)
+                .matchingId(2)
                 .requester(new User())
                 .receiver(receiver)
                 .status(Matching.Status.ACCEPTED)


### PR DESCRIPTION
#### 1. DTO 관련 변경
- **`MatchingCreateRequest`, `MatchingUpdateRequest`**
  - 기존 이름을 명확히 변경하여 역할을 구체화.
- **`MatchingCreateResponse`, `MatchingUpdateResponse`**
  - 매칭 생성 및 상태 업데이트 결과를 처리하는 새로운 DTO 추가.
  - 엔티티와의 변환을 위한 `from(Matching matching)` 메서드 구현.

---

#### 2. `requestId`를 `matchingId`로 변경
- **엔티티 및 관련 클래스**:
  - `Matching`, `MatchingJoin`, `MatchingJoinId`, `MatchingListResponse`에서 `requestId`를 `matchingId`로 변경.
- **DTO**:
  - `MatchingCreateResponse`, `MatchingUpdateRequest`, `MatchingUpdateResponse`에서 `requestId`를 `matchingId`로 변경.
- **서비스 및 테스트**:
  - `MatchingService`, `MatchingServiceTest`에서 관련 메서드 및 필드 이름 변경.
- **컨트롤러 및 테스트**:
  - `MatchingController`, `MatchingControllerTest`에서 JSON 응답 포맷 및 관련 로직 수정.

---

#### 3. MatchingController 리팩토링
- **`createMatchRequest`**
  - 응답 타입을 `ResponseEntity<MatchingCreateResponse>`로 수정.
  - WebSocket 메시지 전송 로직 추가:
    - 경로: `/sub/match-request/{receiverId}`
    - 메시지: `"매칭 요청이 도착했습니다."`
- **`respondToMatchRequest`**
  - 응답 타입을 `ResponseEntity<String>`으로 수정.
  - 성공 시 `"응답 처리 완료"`, 실패 시 `"요청을 찾을 수 없습니다."` 메시지 반환.
  - WebSocket 메시지 전송 유지:
    - 경로: `/sub/match-response/{requesterId}`
    - 메시지:
      - `"매칭 요청이 수락되었습니다."`
      - `"매칭 요청이 거절되었습니다."`

---

#### **테스트**
- **MatchingControllerTest**
  - JSON 응답 포맷 변경 및 `matchingId` 필드 반영.
- **MatchingServiceTest**
  - `requestId`를 `matchingId`로 변경하여 테스트 케이스 수정.
- WebSocket 메시지 전송 여부 확인:
  - 매칭 요청 및 응답 처리 시 WebSocket 메시지가 정상적으로 수신되는지 검증.