### PR TITLE
91 관리자 리뷰 테스트 코드 작성 및 api me 작성

### DIFF
--- a/src/main/java/uni/backend/controller/ProfileController.java
+++ b/src/main/java/uni/backend/controller/ProfileController.java
@@ -1,5 +1,6 @@
 package uni.backend.controller;
 
+import jakarta.persistence.criteria.CriteriaBuilder.In;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import uni.backend.domain.Profile;
 import uni.backend.domain.dto.IndividualProfileResponse;
+import uni.backend.domain.dto.MeResponse;
 import uni.backend.service.AwsS3Service;
 import uni.backend.service.HashtagService;
 import uni.backend.service.PageTranslationService;
@@ -19,6 +21,7 @@ import uni.backend.service.UserService;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import uni.backend.service.UserServiceImpl;
 
 @Controller
 @RequestMapping("/api")
@@ -29,7 +32,15 @@ public class ProfileController {
     private final AwsS3Service awsS3Service;
     private final PageTranslationService pageTranslationService;
     private final TranslationService translationService;
+    private final UserServiceImpl userService;
 
+
+    @GetMapping("/user/me")
+    public ResponseEntity<MeResponse> getCurrentUser() {
+        // 서비스에서 유저 정보를 가져와 응답
+        MeResponse userProfile = userService.getCurrentUserProfile();
+        return ResponseEntity.ok(userProfile);
+    }
 
     @PostMapping("/user/{userId}/update-profile")
     public ResponseEntity<IndividualProfileResponse> updateProfile(

--- a/src/main/java/uni/backend/domain/ReviewReply.java
+++ b/src/main/java/uni/backend/domain/ReviewReply.java
@@ -38,6 +38,7 @@ public class ReviewReply {
     @Column(nullable = false)
     private String content; // 대댓글 본문
 
+    @Builder.Default
     private Long likes = 0L; // 좋아요 수
 
     @Builder.Default

--- a/src/main/java/uni/backend/domain/dto/MeResponse.java
+++ b/src/main/java/uni/backend/domain/dto/MeResponse.java
@@ -1,0 +1,24 @@
+package uni.backend.domain.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import uni.backend.domain.Role;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+public class MeResponse {
+
+    private Integer userId;
+    private String name;
+    private Role role;
+    private String imgProf;
+}

--- a/src/main/java/uni/backend/service/AdminService.java
+++ b/src/main/java/uni/backend/service/AdminService.java
@@ -33,11 +33,15 @@ import uni.backend.repository.UserRepository;
 
 import java.time.LocalDateTime;
 
+/**
+ * 관리자 서비스 관리자 계정 생성, 유저 관리 및 신고된 유저 리스트 조회 기능을 제공
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class AdminService {
 
+    // 필드
     private final UserRepository userRepository;
     private final ReportRepository reportRepository;
     private final AdminAccountUtil adminAccountUtil;
@@ -48,7 +52,7 @@ public class AdminService {
     private final ReplyRepository replyRepository;
 
     /**
-     * 관리자 계정 생성
+     * 관리자 계정 생성 관리자 계정을 생성하고, 생성된 계정 정보를 로그로 기록합니다.
      */
     @Transactional
     public void createAccount() {
@@ -56,14 +60,14 @@ public class AdminService {
         User admin = adminAccountUtil.createAdminAccount(rawPassword);
         userRepository.save(admin);
         log.info("관리자 계정이 생성되었습니다.");
-
     }
 
     /**
-     * 모든 유저 리스트 조회
+     * 모든 유저 리스트 조회 유저 상태와 페이지 정보를 기반으로 유저 리스트를 조회합니다.
      *
-     * @param status   유저 상태 (ACTIVE, INACTIVE, BANNED)
-     * @param pageable 페이징 정보
+     * @param status 유저 상태 (ACTIVE, INACTIVE, BANNED)
+     * @param page   조회할 페이지 번호
+     * @param size   페이지 크기
      * @return 페이징 처리된 유저 리스트
      */
     @Transactional(readOnly = true)
@@ -88,11 +92,11 @@ public class AdminService {
     }
 
     /**
-     * 유저 상태 및 제재 날짜 설정
+     * 유저 상태 변경 및 제재 날짜 설정 유저의 상태를 변경하고, 블라인드 처리를 수행합니다.
      *
-     * @param userId     유저 ID
-     * @param status     변경할 유저 상태
-     * @param banEndDate 제재 해제일
+     * @param userId  유저 ID
+     * @param status  변경할 유저 상태
+     * @param banDays 제재 기간 (일 단위)
      */
     @Transactional
     public void updateUserStatus(Integer userId, UserStatus status, Integer banDays) {
@@ -123,9 +127,10 @@ public class AdminService {
     }
 
     /**
-     * 신고된 유저 리스트 조회 (페이징 처리)
+     * 신고된 유저 리스트 조회 신고 데이터를 기반으로 신고된 유저 리스트를 페이징 처리하여 반환합니다.
      *
-     * @param pageable 페이징 정보
+     * @param page 조회할 페이지 번호
+     * @param size 페이지 크기
      * @return 페이징 처리된 신고된 유저 리스트
      */
     @Transactional(readOnly = true)
@@ -164,7 +169,9 @@ public class AdminService {
     }
 
     /**
-     * 유저의 모든 콘텐츠 블라인드 처리
+     * 유저의 모든 콘텐츠 블라인드 처리 특정 유저의 QnA, 리뷰, 답글 등을 블라인드 처리합니다.
+     *
+     * @param userId 블라인드 처리할 유저 ID
      */
     @Transactional
     public void blindAllContentByUser(Integer userId) {
@@ -193,6 +200,11 @@ public class AdminService {
         log.info("유저 ID={}의 모든 리뷰 리플라이를 블라인드 처리했습니다.", userId);
     }
 
+    /**
+     * 유저의 모든 콘텐츠 블라인드 해제 특정 유저의 QnA, 리뷰, 답글 등을 블라인드 해제합니다.
+     *
+     * @param userId 블라인드 해제할 유저 ID
+     */
     @Transactional
     public void unblindAllContentByUser(Integer userId) {
         // QnA 블라인드 해제
@@ -219,5 +231,4 @@ public class AdminService {
         reviewReplyRepository.saveAll(reviewReplies);
         log.info("유저 ID={}의 모든 리뷰 리플라이 블라인드 상태를 해제했습니다.", userId);
     }
-
 }

--- a/src/main/java/uni/backend/service/UserServiceImpl.java
+++ b/src/main/java/uni/backend/service/UserServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -13,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 import uni.backend.domain.Profile;
 import uni.backend.domain.User;
 import uni.backend.domain.UserStatus;
+import uni.backend.domain.dto.MeResponse;
 import uni.backend.exception.UserStatusException;
 import uni.backend.repository.UserRepository;
 
@@ -47,7 +49,7 @@ public class UserServiceImpl implements UserService {
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+            .orElseThrow(() -> new UsernameNotFoundException("User not found"));
 
         if (user.getStatus() == UserStatus.BANNED) {
             log.warn("Banned user {} tried to log in", user.getEmail());
@@ -112,4 +114,20 @@ public class UserServiceImpl implements UserService {
         userRepository.save(user);
         resetCodes.remove(email);
     }
+
+    public MeResponse getCurrentUserProfile() {
+        // SecurityContext에서 현재 사용자 가져오기
+        String currentUserEmail = SecurityContextHolder.getContext().getAuthentication().getName();
+        User currentUser = userRepository.findByEmail(currentUserEmail)
+            .orElseThrow(() -> new IllegalArgumentException("로그인된 사용자를 찾을 수 없습니다."));
+
+        return MeResponse.builder()
+            .userId(currentUser.getUserId())
+            .name(currentUser.getName())
+            .role(currentUser.getRole())
+            .imgProf(
+                currentUser.getProfile() != null ? currentUser.getProfile().getImgProf() : null)
+            .build();
+    }
+
 }

--- a/src/test/java/uni/backend/service/AdminServiceTest.java
+++ b/src/test/java/uni/backend/service/AdminServiceTest.java
@@ -1,0 +1,194 @@
+package uni.backend.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import uni.backend.domain.*;
+import uni.backend.domain.dto.UserResponse;
+import uni.backend.domain.util.AdminAccountUtil;
+import uni.backend.repository.*;
+
+class AdminServiceTest {
+
+    @InjectMocks
+    private AdminService adminService;
+    @Mock
+    private ReportCategory reportCategory;
+    @Mock
+    private ReportReason reportReason;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ReportRepository reportRepository;
+
+    @Mock
+    private AdminAccountUtil adminAccountUtil;
+
+    @Mock
+    private QnaRepository qnaRepository;
+
+    @Mock
+    private ReviewRepository reviewRepository;
+
+    @Mock
+    private ProfileRepository profileRepository;
+
+    @Mock
+    private ReviewReplyRepository reviewReplyRepository;
+
+    @Mock
+    private ReplyRepository replyRepository;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        user = User.builder()
+            .userId(1)
+            .email("test@example.com")
+            .name("Test User")
+            .status(UserStatus.ACTIVE)
+            .build();
+    }
+
+    @Test
+    @DisplayName("관리자 계정 생성 성공 테스트")
+    void createAccount_성공() {
+        // given
+        String rawPassword = "randomPassword123";
+        User admin = User.builder()
+            .userId(99)
+            .email("admin@example.com")
+            .password(rawPassword)
+            .build();
+
+        when(adminAccountUtil.createAdminPassword()).thenReturn(rawPassword);
+        when(adminAccountUtil.createAdminAccount(rawPassword)).thenReturn(admin);
+        when(userRepository.save(any(User.class))).thenReturn(admin);
+
+        // when
+        adminService.createAccount();
+
+        // then
+        verify(adminAccountUtil).createAdminPassword();
+        verify(adminAccountUtil).createAdminAccount(rawPassword);
+        verify(userRepository).save(admin);
+    }
+
+    @Test
+    @DisplayName("유저 상태 업데이트 성공 테스트")
+    void updateUserStatus_성공() {
+        // given
+        when(userRepository.findById(user.getUserId())).thenReturn(Optional.of(user));
+        doNothing().when(qnaRepository).setBlindStatusByUserId(user.getUserId(), true);
+        // when
+        adminService.updateUserStatus(user.getUserId(), UserStatus.BANNED, 7);
+
+        // then
+        assertEquals(UserStatus.BANNED, user.getStatus());
+        assertNotNull(user.getEndBanDate());
+        verify(userRepository).save(user);
+        verify(qnaRepository).setBlindStatusByUserId(user.getUserId(), true);
+    }
+
+    @Test
+    @DisplayName("신고된 유저 리스트 조회 성공 테스트")
+    void getReportedUsers_성공() {
+        // given
+        User reportedUser = User.builder()
+            .userId(2)
+            .email("reported@example.com")
+            .build();
+
+        Report report1 = Report.builder()
+            .reportedUser(reportedUser)
+            .category(ReportCategory.CHAT)
+            .reason(ReportReason.SPAM)
+            .detailedReason("Spam content")
+            .build();
+
+        List<Report> reports = List.of(report1);
+
+        when(reportRepository.findAll()).thenReturn(reports);
+
+        // when
+        var result = adminService.getReportedUsers(1, 10);
+
+        // then
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        verify(reportRepository).findAll();
+    }
+
+    @Test
+    @DisplayName("유저 콘텐츠 블라인드 처리 성공 테스트")
+    void blindAllContentByUser_성공() {
+        // given
+        List<Qna> qnas = new ArrayList<>();
+        List<Reply> replies = new ArrayList<>();
+        List<Review> reviews = new ArrayList<>();
+        List<ReviewReply> reviewReplies = new ArrayList<>();
+
+        Qna qna = new Qna();
+        qnas.add(qna);
+
+        when(qnaRepository.findByCommenter_UserId(user.getUserId())).thenReturn(qnas);
+        when(replyRepository.findByCommenter_UserId(user.getUserId())).thenReturn(replies);
+        when(reviewRepository.findByCommenter_UserId(user.getUserId())).thenReturn(reviews);
+        when(reviewReplyRepository.findByCommenter_UserId(user.getUserId())).thenReturn(
+            reviewReplies);
+
+        // when
+        adminService.blindAllContentByUser(user.getUserId());
+
+        // then
+        verify(qnaRepository).findByCommenter_UserId(user.getUserId());
+        verify(replyRepository).findByCommenter_UserId(user.getUserId());
+        verify(reviewRepository).findByCommenter_UserId(user.getUserId());
+        verify(reviewReplyRepository).findByCommenter_UserId(user.getUserId());
+    }
+
+    @Test
+    @DisplayName("유저 콘텐츠 블라인드 해제 성공 테스트")
+    void unblindAllContentByUser_성공() {
+        // given
+        List<Qna> qnas = new ArrayList<>();
+        List<Reply> replies = new ArrayList<>();
+        List<Review> reviews = new ArrayList<>();
+        List<ReviewReply> reviewReplies = new ArrayList<>();
+
+        Qna qna = new Qna();
+        qnas.add(qna);
+
+        when(qnaRepository.findByCommenter_UserId(user.getUserId())).thenReturn(qnas);
+        when(replyRepository.findByCommenter_UserId(user.getUserId())).thenReturn(replies);
+        when(reviewRepository.findByCommenter_UserId(user.getUserId())).thenReturn(reviews);
+        when(reviewReplyRepository.findByCommenter_UserId(user.getUserId())).thenReturn(
+            reviewReplies);
+
+        // when
+        adminService.unblindAllContentByUser(user.getUserId());
+
+        // then
+        verify(qnaRepository).findByCommenter_UserId(user.getUserId());
+        verify(replyRepository).findByCommenter_UserId(user.getUserId());
+        verify(reviewRepository).findByCommenter_UserId(user.getUserId());
+        verify(reviewReplyRepository).findByCommenter_UserId(user.getUserId());
+    }
+}

--- a/src/test/java/uni/backend/service/ReviewReplyServiceTest.java
+++ b/src/test/java/uni/backend/service/ReviewReplyServiceTest.java
@@ -1,0 +1,210 @@
+package uni.backend.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import uni.backend.domain.Matching;
+import uni.backend.domain.Profile;
+import uni.backend.domain.Review;
+import uni.backend.domain.ReviewReply;
+import uni.backend.domain.ReviewReplyLikes;
+import uni.backend.domain.User;
+import uni.backend.domain.dto.ReviewReplyResponse;
+import uni.backend.repository.ReviewReplyLikeRepository;
+import uni.backend.repository.ReviewReplyRepository;
+import uni.backend.repository.ReviewRepository;
+import uni.backend.repository.UserRepository;
+
+class ReviewReplyServiceTest {
+
+    @InjectMocks
+    private ReviewReplyService reviewReplyService;
+
+    @Mock
+    private ReviewReplyRepository reviewReplyRepository;
+
+    @Mock
+    private ReviewRepository reviewRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ReviewReplyLikeRepository reviewReplyLikeRepository; // Mock 추가
+
+    private Review review;
+    private User profileOwner;
+    private User commenter;
+    private Matching matching;
+    private ReviewReply reviewReply;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        Profile profile = Profile.builder()
+            .imgProf("example-image-url")
+            .build();
+
+        profileOwner = User.builder()
+            .userId(1)
+            .name("Profile Owner")
+            .email("owner@example.com")
+            .password("password")
+            .profile(profile)
+            .build();
+
+        commenter = User.builder()
+            .userId(2)
+            .name("Commenter")
+            .email("commenter@example.com")
+            .password("password")
+            .profile(profile)
+            .build();
+
+        review = Review.builder()
+            .reviewId(1)
+            .profileOwner(profileOwner)
+            .commenter(commenter)
+            .content("Initial review content")
+            .likes(1L)
+            .deleted(false)
+            .build();
+
+        reviewReply = ReviewReply.builder()
+            .replyId(1)
+            .review(review)
+            .commenter(commenter)
+            .content("Test reply")
+            .likes(0L)
+            .deleted(false)
+            .build();
+    }
+
+
+    @Test
+    @DisplayName("대댓글 작성 성공 테스트")
+    void createReviewReply_성공() {
+        // given
+        when(reviewRepository.findById(review.getReviewId())).thenReturn(Optional.of(review));
+        when(userRepository.findById(commenter.getUserId())).thenReturn(Optional.of(commenter));
+        when(reviewReplyRepository.save(any(ReviewReply.class))).thenAnswer(
+            invocation -> invocation.getArgument(0));
+
+        // when
+        ReviewReplyResponse createdReply = reviewReplyService.createReviewReply(
+            review.getReviewId(),
+            commenter.getUserId(),
+            "New reply content"
+        );
+
+        // then
+        assertNotNull(createdReply);
+        assertEquals("New reply content", createdReply.getContent());
+        assertEquals(review.getReviewId(), createdReply.getReviewId());
+        assertEquals(commenter.getUserId(), createdReply.getCommenterId());
+        assertEquals(0L, createdReply.getLikes()); // 좋아요 초기값 확인
+        assertFalse(createdReply.getDeleted()); // 삭제 여부 확인
+
+        // 검증: 저장 메서드 호출 여부 확인
+        verify(reviewReplyRepository).save(any(ReviewReply.class));
+    }
+
+
+    @Test
+    @DisplayName("대댓글 삭제 성공 테스트")
+    void deleteReply_성공() {
+        // given
+        when(reviewReplyRepository.findById(reviewReply.getReplyId())).thenReturn(
+            Optional.of(reviewReply));
+        when(reviewReplyRepository.save(any(ReviewReply.class))).thenAnswer(
+            invocation -> invocation.getArgument(0));
+
+        // when
+        ReviewReply deletedReply = reviewReplyService.deleteReply(reviewReply.getReplyId());
+
+        // then
+        assertNotNull(deletedReply);
+        assertTrue(deletedReply.getDeleted());
+        assertNotNull(deletedReply.getDeletedTime());
+
+        verify(reviewReplyRepository).save(deletedReply);
+    }
+
+    @Test
+    @DisplayName("대댓글 수정 성공 테스트")
+    void updateReplyContent_성공() {
+        // given
+        String updatedContent = "Updated content";
+        when(reviewReplyRepository.findById(reviewReply.getReplyId())).thenReturn(
+            Optional.of(reviewReply));
+
+        // when
+        reviewReplyService.updateReplyContent(reviewReply.getReplyId(), updatedContent);
+
+        // then
+        assertEquals(updatedContent, reviewReply.getContent());
+        assertNotNull(reviewReply.getUpdatedTime());
+
+        // 검증: 업데이트된 객체가 저장되었는지 확인
+        verify(reviewReplyRepository).save(reviewReply);
+    }
+
+    @Test
+    @DisplayName("좋아요 추가 테스트")
+    void toggleLike_좋아요_추가() {
+        // given
+        // 좋아요가 없는 상태로 설정
+        when(reviewReplyRepository.findById(reviewReply.getReplyId())).thenReturn(
+            Optional.of(reviewReply));
+        when(userRepository.findById(commenter.getUserId())).thenReturn(Optional.of(commenter));
+        when(reviewReplyLikeRepository.findByUserAndReviewReply(commenter, reviewReply)).thenReturn(
+            Optional.empty());
+
+        // when
+        reviewReplyService.toggleLike(reviewReply.getReplyId(), commenter);
+
+        // then
+        assertEquals(1L, reviewReply.getLikes()); // 좋아요 수가 1로 증가했는지 확인
+        verify(reviewReplyLikeRepository).save(any()); // 좋아요 저장 호출 확인
+        verify(reviewReplyRepository).save(reviewReply); // 업데이트된 ReviewReply 저장 호출 확인
+    }
+
+    @Test
+    @DisplayName("좋아요 취소 테스트")
+    void toggleLike_좋아요_취소() {
+        // given
+        // 좋아요가 이미 눌린 상태로 설정
+        ReviewReplyLikes existingLike = ReviewReplyLikes.builder()
+            .user(commenter)
+            .reviewReply(reviewReply)
+            .build();
+        reviewReply.increaseLikes(); // 좋아요 수를 1로 설정
+
+        when(reviewReplyRepository.findById(reviewReply.getReplyId())).thenReturn(
+            Optional.of(reviewReply));
+        when(userRepository.findById(commenter.getUserId())).thenReturn(Optional.of(commenter));
+        when(reviewReplyLikeRepository.findByUserAndReviewReply(commenter, reviewReply)).thenReturn(
+            Optional.of(existingLike));
+
+        // when
+        reviewReplyService.toggleLike(reviewReply.getReplyId(), commenter);
+
+        // then
+        assertEquals(0L, reviewReply.getLikes()); // 좋아요 수가 0으로 감소했는지 확인
+        verify(reviewReplyLikeRepository).delete(existingLike); // 좋아요 삭제 호출 확인
+        verify(reviewReplyRepository).save(reviewReply); // 업데이트된 ReviewReply 저장 호출 확인
+    }
+
+}


### PR DESCRIPTION
[FEAT] 현재 사용자 정보 조회 API 추가
현재 로그인된 사용자의 정보를 반환하는 /api/user/me 엔드포인트를 추가했습니다.

- SecurityContextHolder를 통해 인증된 사용자 정보를 가져옵니다.
- MeResponse 객체를 통해 사용자 ID, 이름, 역할, 프로필 이미지를 반환합니다.
- 프로필 정보가 없는 경우 null 처리로 안전성을 보장합니다.

[TEST] AdminService 테스트 코드 추가

- 관리자 계정 생성(createAccount) 테스트 추가
- 유저 상태 업데이트(updateUserStatus) 테스트 추가
- 신고된 유저 리스트 조회(getReportedUsers) 테스트 추가
- 유저 콘텐츠 블라인드 처리(blindAllContentByUser) 테스트 추가
- 유저 콘텐츠 블라인드 해제(unblindAllContentByUser) 테스트 추가

[TEST] ReviewReplyService 좋아요 기능 테스트 추가

좋아요 추가 및 취소 로직의 단위 테스트를 작성했습니다.
Mockito를 사용하여 Mock 객체를 설정하고 성공 케이스를 검증했습니다.
기본 데이터 설정은 @beforeeach 어노테이션을 활용했습니다.