### PR TITLE
93 관리자 계정 생성 시 메일 전송 및 프로필 정렬 로직 테스트

### DIFF
--- a/src/main/java/uni/backend/controller/AdminController.java
+++ b/src/main/java/uni/backend/controller/AdminController.java
@@ -1,5 +1,6 @@
 package uni.backend.controller;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -25,9 +26,19 @@ public class AdminController {
      */
     @PostMapping("/create-account")
     public ResponseEntity<String> createAdminAccount() {
-        adminService.createAccount();
-        return ResponseEntity.ok("관리자 계정이 생성되었습니다.");
+        List<String> recipientEmails = List.of(
+            "gbe0808@ajou.ac.kr",
+            "uko802@ajou.ac.kr",
+            "ljy9085@ajou.ac.kr",
+            "han1267@ajou.ac.kr",
+            "nicola1928@ajou.ac.kr"
+        );
+
+        // recipientEmails 전달
+        adminService.createAccountAndSendToMultipleRecipients(recipientEmails);
+        return ResponseEntity.ok("관리자 계정이 생성되었으며 이메일이 발송되었습니다.");
     }
+
 
     /**
      * 모든 유저 리스트 조회

--- a/src/main/java/uni/backend/domain/util/AdminAccountUtil.java
+++ b/src/main/java/uni/backend/domain/util/AdminAccountUtil.java
@@ -5,54 +5,69 @@ import java.security.SecureRandom;
 import java.util.Random;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import uni.backend.domain.User;
 import uni.backend.domain.Role;
 import uni.backend.domain.UserStatus;
 
-
 @Component
 @RequiredArgsConstructor
 public class AdminAccountUtil {
 
-    private static final String ADMIN_PREFIX = "SYSTEM_ADMIN";
-    public static final String ADMIN_EMAIL = "admin@uni.site"; // 관리자 고정 이메일
-    private static final int SECURITY_DIGIT_NUMBER = 6;
-    private static final int RANDOM_NUMBER_BOUND = 10;
+    private static final String TITLE_MESSAGE = "[UNI] PLEASE Don't expose your password";
+    private static final int SECURITY_DIGIT_NUMBER = 6; // 랜덤 숫자 자리수
+    private static final int RANDOM_NUMBER_BOUND = 10; // 랜덤 숫자의 최대값
+    private static final String ADMIN_PREFIX = "ADMIN"; // 관리자 계정 접두사
 
     private final PasswordEncoder passwordEncoder;
 
     /**
      * 관리자 계정 생성
      *
-     * @return 생성된 User 엔티티 (관리자)
+     * @param rawPassword 생성된 비밀번호
+     * @return 생성된 User 객체
      */
     public User createAdminAccount(String rawPassword) {
         User admin = new User();
-        admin.setEmail(ADMIN_EMAIL); // 고정된 관리자 이메일
-        admin.setPassword(passwordEncoder.encode(rawPassword)); // 암호화된 비밀번호 저장
-        admin.setStatus(UserStatus.ACTIVE);
-        admin.setRole(Role.ADMIN);
-        admin.setName("System Admin");
-        admin.setAdminId(UUID.randomUUID().toString()); // UUID로 고유 관리 ID 생성
+        admin.setEmail(createAdminName()); // 고유한 관리자 이메일 생성
+        admin.setPassword(passwordEncoder.encode(rawPassword)); // 비밀번호 암호화 후 저장
+        admin.setStatus(UserStatus.ACTIVE); // 활성화 상태 설정
+        admin.setRole(Role.ADMIN); // 역할을 관리자(Admin)로 설정
+        admin.setName("System Admin"); // 관리자 기본 이름 설정
+        admin.setAdminId(UUID.randomUUID().toString()); // 고유 Admin ID 설정
         return admin;
     }
 
     /**
+     * 관리자 이메일 생성
+     *
+     * @return 고유한 이메일 문자열
+     */
+    public String createAdminName() {
+        String randomSuffix = String.format("%06d", new Random().nextInt(999999));
+        return String.format("admin%s@uni-ajou.site", randomSuffix);
+    }
+
+    /**
      * 랜덤한 관리자 비밀번호 생성
+     *
+     * @return 생성된 비밀번호
      */
     public String createAdminPassword() {
         return UUID.randomUUID().toString() + createRandomCodeNumber();
     }
 
     /**
-     * 랜덤 숫자 생성 로직 (보안 강화를 위해 SecureRandom 사용)
+     * 랜덤 숫자 생성
+     *
+     * @return 보안 강화된 랜덤 숫자 문자열
      */
     private String createRandomCodeNumber() {
         try {
             Random random = SecureRandom.getInstanceStrong();
-            return createRandomNumber(random);
+            return generateRandomNumberSequence(random);
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException("SecureRandom instance could not be created.", e);
         }
@@ -60,12 +75,43 @@ public class AdminAccountUtil {
 
     /**
      * 랜덤 숫자 시퀀스 생성
+     *
+     * @param random 랜덤 생성기
+     * @return 랜덤 숫자 문자열
      */
-    private String createRandomNumber(Random random) {
+    private String generateRandomNumberSequence(Random random) {
         StringBuilder builder = new StringBuilder();
         for (int i = 0; i < SECURITY_DIGIT_NUMBER; i++) {
             builder.append(random.nextInt(RANDOM_NUMBER_BOUND));
         }
         return builder.toString();
+    }
+
+    /**
+     * 이메일 메시지 생성
+     *
+     * @param toEmail   수신자 이메일
+     * @param adminName 관리자 이름
+     * @param password  관리자 비밀번호
+     * @return 이메일 메시지 객체
+     */
+    public static SimpleMailMessage createEmailForm(String toEmail, String adminName,
+        String password) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(toEmail);
+        message.setSubject(TITLE_MESSAGE);
+        message.setText(formatEmailText(adminName, password));
+        return message;
+    }
+
+    /**
+     * 이메일 본문 텍스트 포맷
+     *
+     * @param adminName 관리자 이름
+     * @param password  관리자 비밀번호
+     * @return 포맷된 이메일 텍스트
+     */
+    private static String formatEmailText(String adminName, String password) {
+        return String.format("[Admin Account: %s], [Password: %s]", adminName, password);
     }
 }

--- a/src/test/java/uni/backend/service/HomeServiceTest.java
+++ b/src/test/java/uni/backend/service/HomeServiceTest.java
@@ -1,0 +1,160 @@
+package uni.backend.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import uni.backend.domain.Hashtag;
+import uni.backend.domain.MainCategory;
+import uni.backend.domain.Profile;
+import uni.backend.domain.User;
+import uni.backend.domain.dto.HomeProfileResponse;
+import uni.backend.repository.ProfileRepository;
+
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+public class HomeServiceTest {
+
+    @InjectMocks
+    private HomeService homeService;
+
+    @Mock
+    private ProfileRepository profileRepository;
+
+    private Profile profile1;
+    private Profile profile2;
+    private Profile profile3;
+    private User user1;
+    private User user2;
+    private User user3;
+    private List<String> hashtags;
+
+    private MainCategory createMainCategoryWithHashtag(String hashtagName) {
+        Hashtag hashtag = new Hashtag();
+        hashtag.setHashtagName(hashtagName);
+
+        MainCategory mainCategory = new MainCategory();
+        mainCategory.setHashtag(hashtag);
+
+        return mainCategory;
+    }
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        // 사용자와 프로필 생성
+        user1 = User.builder().userId(1).name("User1").univName("University A").build();
+        user2 = User.builder().userId(2).name("User2").univName("University A").build();
+        user3 = User.builder().userId(3).name("User3").univName("University B").build();
+
+        profile1 = new Profile();
+        profile1.setUser(user1);
+        profile1.setImgProf("/img1.png");
+        profile1.setStar(4.5);
+
+        profile2 = new Profile();
+        profile2.setUser(user2);
+        profile2.setImgProf("/img2.png");
+        profile2.setStar(3.0);
+
+        profile3 = new Profile();
+        profile3.setUser(user3);
+        profile3.setImgProf("/img3.png");
+        profile3.setStar(5.0);
+
+        // 해시태그 추가
+        hashtags = List.of("Hashtag1", "Hashtag2");
+        hashtags.forEach(
+            hashtagName -> {
+                profile1.addMainCategory(createMainCategoryWithHashtag(hashtagName));
+                profile2.addMainCategory(createMainCategoryWithHashtag(hashtagName));
+            });
+    }
+
+    @Test
+    @DisplayName("Profile -> HomeProfileResponse 변환 성공 테스트")
+    void profileToHomeProfileResponse_성공() {
+        // when
+        HomeProfileResponse homeProfileResponse = homeService.profileToHomeProfileResponse(
+            profile1);
+
+        // then
+        assertEquals("User1", homeProfileResponse.getUsername());
+        assertEquals("/img1.png", homeProfileResponse.getImgProf());
+        assertEquals(4.5, homeProfileResponse.getStar());
+        assertEquals("University A", homeProfileResponse.getUnivName());
+        assertTrue(homeProfileResponse.getHashtags().containsAll(hashtags));
+    }
+
+    @Test
+    @DisplayName("대학교 이름과 해시태그로 검색 성공 테스트 - 정렬 기준: 최신순")
+    void searchByUnivNameAndHashtags_최신순_성공() {
+        // Given
+        List<Profile> profiles = List.of(profile1, profile2);
+        Page<Profile> page = new PageImpl<>(profiles, PageRequest.of(0, 10), profiles.size());
+
+        when(profileRepository.findByUnivNameAndHashtags(anyString(), any(), anyInt(), any()))
+            .thenReturn(page);
+
+        // When
+        Page<HomeProfileResponse> result = homeService.searchByUnivNameAndHashtags(
+            "University A", hashtags, 1, "newest");
+
+        // Then
+        assertEquals(2, result.getTotalElements());
+        verify(profileRepository).findByUnivNameAndHashtags(anyString(), any(), anyInt(), any());
+    }
+
+    @Test
+    @DisplayName("대학교 이름과 해시태그로 검색 성공 테스트 - 정렬 기준: 높은 평점순")
+    void searchByUnivNameAndHashtags_높은평점순_성공() {
+        // Given
+        List<Profile> profiles = List.of(profile3, profile1);
+        Page<Profile> page = new PageImpl<>(profiles, PageRequest.of(0, 10), profiles.size());
+
+        when(profileRepository.findByUnivNameAndHashtags(anyString(), any(), anyInt(), any()))
+            .thenReturn(page);
+
+        // When
+        Page<HomeProfileResponse> result = homeService.searchByUnivNameAndHashtags(
+            "University A", hashtags, 1, "highest_rating");
+
+        // Then
+        assertEquals(2, result.getTotalElements());
+        assertEquals("User3", result.getContent().get(0).getUsername());
+        verify(profileRepository).findByUnivNameAndHashtags(anyString(), any(), anyInt(), any());
+    }
+
+    @Test
+    @DisplayName("대학교 이름과 해시태그로 검색 성공 테스트 - 정렬 기준: 낮은 평점순")
+    void searchByUnivNameAndHashtags_낮은평점순_성공() {
+        // Given
+        List<Profile> profiles = List.of(profile2, profile1);
+        Page<Profile> page = new PageImpl<>(profiles, PageRequest.of(0, 10), profiles.size());
+
+        when(profileRepository.findByUnivNameAndHashtags(anyString(), any(), anyInt(), any()))
+            .thenReturn(page);
+
+        // When
+        Page<HomeProfileResponse> result = homeService.searchByUnivNameAndHashtags(
+            "University A", hashtags, 1, "lowest_rating");
+
+        // Then
+        assertEquals(2, result.getTotalElements());
+        assertEquals("User2", result.getContent().get(0).getUsername());
+        verify(profileRepository).findByUnivNameAndHashtags(anyString(), any(), anyInt(), any());
+    }
+}


### PR DESCRIPTION
[TEST] HomeService 테스트 코드 추가

HomeService에 대한 테스트 코드를 추가했습니다.
- Profile -> HomeProfileResponse 변환 테스트
- 대학교 이름과 해시태그로 검색 테스트
  - 정렬 기준: 최신순, 높은 평점순, 낮은 평점순

[FEAT] 관리자 계정 생성 시 이메일 전송 기능 추가

- 관리자 계정 생성 시 지정된 이메일 목록으로 계정 정보와 초기 비밀번호를 전송하는 기능을 추가했습니다.
- JavaMailSender를 활용하여 SMTP를 통해 이메일 전송을 구현했습니다.
- 랜덤하게 생성된 관리자 비밀번호와 고유 관리자 이메일이 포함된 메시지를 전송합니다.