### PR TITLE
[FEAT] 대기 요청 중복 생성 제한 로직 및 대기 요청 확인 메서드 추가

### DIFF
--- a/src/main/java/uni/backend/repository/MatchingRepository.java
+++ b/src/main/java/uni/backend/repository/MatchingRepository.java
@@ -4,8 +4,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import uni.backend.domain.Matching;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MatchingRepository extends JpaRepository<Matching, Integer> {
+
     List<Matching> findByRequester_UserId(Integer requesterId);
+
     List<Matching> findByReceiver_UserId(Integer receiverId);
+
+    Optional<Matching> findByRequester_UserIdAndReceiver_UserIdAndStatus(Integer requesterId, Integer receiverId, Matching.Status status);
+
 }

--- a/src/main/java/uni/backend/service/MatchingService.java
+++ b/src/main/java/uni/backend/service/MatchingService.java
@@ -21,21 +21,21 @@ public class MatchingService {
     @Transactional
     public Matching createRequest(Matching matching, User requester, User receiver) {
         Matching request = Matching.builder()
-            .requester(requester)
-            .receiver(receiver)
-            .status(Matching.Status.PENDING)
-            .createdAt(LocalDateTime.now())
-            .build();
+                .requester(requester)
+                .receiver(receiver)
+                .status(Matching.Status.PENDING)
+                .createdAt(LocalDateTime.now())
+                .build();
         return matchingRepository.save(request);
     }
 
     @Transactional
     public Optional<Matching> updateRequestStatus(MatchingUpdateRequest matchingUpdateRequest) {
         Optional<Matching> requestOpt = matchingRepository.findById(
-            matchingUpdateRequest.getMatchingId());
+                matchingUpdateRequest.getMatchingId());
         requestOpt.ifPresent(request -> {
             request.setStatus(matchingUpdateRequest.isAccepted() ? Matching.Status.ACCEPTED
-                : Matching.Status.REJECTED);
+                    : Matching.Status.REJECTED);
             matchingRepository.save(request);
         });
         return requestOpt;
@@ -51,13 +51,19 @@ public class MatchingService {
 
     public MatchingResponse getMatchingInfo(Integer matchingId) {
         Matching matching = matchingRepository.findById(matchingId)
-            .orElseThrow(
-                () -> new IllegalArgumentException("Matching not found with ID: " + matchingId));
+                .orElseThrow(
+                        () -> new IllegalArgumentException("Matching not found with ID: " + matchingId));
 
         Integer profileOwnerId = matching.getReceiver().getUserId(); // 리시버가 프로필 주인
         Integer requesterId = matching.getRequester().getUserId();
 
         return new MatchingResponse(matching.getMatchingId(), profileOwnerId, requesterId);
+    }
+
+    @Transactional
+    public Optional<Matching> findPendingRequest(Integer requesterId, Integer receiverId) {
+        return matchingRepository.findByRequester_UserIdAndReceiver_UserIdAndStatus(
+                requesterId, receiverId, Matching.Status.PENDING);
     }
 
 }


### PR DESCRIPTION
매칭 요청이 연속해서 들어오면, 해당 요청자를 보고 이미 존재하는 매칭 요청이 있다면 해당 매칭 요청을 반환하도록 변경했습니다.