### PR TITLE
[CHORE] 세션 기반 인증에서 JWT 토큰 기반 인증으로 전환

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,10 +39,14 @@ dependencies {
     implementation 'com.deepl.api:deepl-java:1.6.0'
     implementation 'org.springframework.boot:spring-boot-starter-webflux:3.3.4'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
-    implementation 'org.springframework.session:spring-session-core'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'jakarta.servlet:jakarta.servlet-api:5.0.0'
+
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
-
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/uni/backend/config/SecurityConfig.java
+++ b/src/main/java/uni/backend/config/SecurityConfig.java
@@ -13,11 +13,11 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.session.web.http.CookieSerializer;
-import org.springframework.session.web.http.DefaultCookieSerializer;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import uni.backend.security.JwtAuthenticationFilter;
 import uni.backend.service.UserService;
 
 import java.util.List;
@@ -28,6 +28,7 @@ import java.util.List;
 public class SecurityConfig {
 
     private final UserService userService;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -35,17 +36,15 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session
-                        .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/home", "/api/auth/**", "/ws/**").permitAll()
-//                      .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated())
-                .authenticationProvider(authenticationProvider());
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
-
-
 
     @Bean
     public AuthenticationManager authenticationManagerBean(AuthenticationConfiguration authenticationConfiguration) throws Exception {
@@ -71,19 +70,10 @@ public class SecurityConfig {
         configuration.setAllowedOriginPatterns(List.of("*"));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
-        configuration.setAllowCredentials(true); // 쿠키, 인증정보 포함 허용
+        configuration.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
-    }
-
-    @Bean
-    public CookieSerializer cookieSerializer() {
-        DefaultCookieSerializer serializer = new DefaultCookieSerializer();
-        serializer.setCookieName("JSESSIONID"); // 쿠키 이름 설정
-        serializer.setSameSite("None");        // SameSite=None 설정
-        serializer.setCookiePath("/");         // 쿠키의 경로 설정
-        return serializer;
     }
 }

--- a/src/main/java/uni/backend/domain/RefreshToken.java
+++ b/src/main/java/uni/backend/domain/RefreshToken.java
@@ -1,0 +1,32 @@
+package uni.backend.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Setter
+@Getter
+@Entity
+@Table(name = "refresh_tokens")
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer tokenId;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @Column(name = "expires_at", nullable = false)
+    private Instant expiresAt;
+
+    @Column(nullable = false)
+    private boolean revoked = false;
+}
+

--- a/src/main/java/uni/backend/domain/Role.java
+++ b/src/main/java/uni/backend/domain/Role.java
@@ -1,5 +1,12 @@
 package uni.backend.domain;
 
-public enum Role {
-    ADMIN, KOREAN, EXCHANGE
+import org.springframework.security.core.GrantedAuthority;
+
+public enum Role implements GrantedAuthority {
+    ADMIN, KOREAN, EXCHANGE;
+
+    @Override
+    public String getAuthority() {
+        return name(); // 권한 이름으로 역할 이름 반환
+    }
 }

--- a/src/main/java/uni/backend/domain/dto/LoginResponse.java
+++ b/src/main/java/uni/backend/domain/dto/LoginResponse.java
@@ -14,5 +14,7 @@ public class LoginResponse {
     private Boolean isKorean;
     private String imgProf;
     private String imgBack;
+    private String accessToken;
+    private String refreshToken;
 }
 

--- a/src/main/java/uni/backend/repository/RefreshTokenRepository.java
+++ b/src/main/java/uni/backend/repository/RefreshTokenRepository.java
@@ -1,0 +1,17 @@
+package uni.backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import uni.backend.domain.RefreshToken;
+
+import java.time.Instant;
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Integer> {
+
+    Optional<RefreshToken> findByToken(String token);
+
+    void deleteAllByExpiresAtBefore(Instant now);
+}
+

--- a/src/main/java/uni/backend/security/JwtAuthenticationFilter.java
+++ b/src/main/java/uni/backend/security/JwtAuthenticationFilter.java
@@ -1,0 +1,46 @@
+package uni.backend.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtils jwtUtils;
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain)
+            throws ServletException, IOException {
+        String jwt = jwtUtils.getJwtFromRequest(request);
+
+        if (StringUtils.hasText(jwt) && jwtUtils.validateJwtToken(jwt)) {
+            String email = jwtUtils.getEmailFromJwtToken(jwt);
+
+            UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+
+            UsernamePasswordAuthenticationToken authenticationToken =
+                    new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+            SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/uni/backend/security/JwtUtils.java
+++ b/src/main/java/uni/backend/security/JwtUtils.java
@@ -1,0 +1,88 @@
+package uni.backend.security;
+
+import io.jsonwebtoken.*;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import uni.backend.domain.Role;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.security.Key;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtUtils {
+
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+
+    @Value("${jwt.expiration}")
+    private long jwtExpirationMs;
+
+    private Key key;
+
+    @PostConstruct
+    private void initializeKey() {
+        if (key == null) {
+            this.key = new SecretKeySpec(jwtSecret.getBytes(), SignatureAlgorithm.HS256.getJcaName());
+        }
+    }
+
+    public String generateJwtToken(String email) {
+        initializeKey();
+        return Jwts.builder()
+                .setSubject(email)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date((new Date()).getTime() + jwtExpirationMs))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String generateJwtToken(String email, Role role) {
+        initializeKey();
+        JwtBuilder builder = Jwts.builder()
+                .setSubject(email)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date((new Date()).getTime() + jwtExpirationMs))
+                .signWith(key, SignatureAlgorithm.HS256);
+        if (role != null) {
+            builder.claim("role", role.name());
+        }
+        return builder.compact();
+    }
+
+    public String getEmailFromJwtToken(String token) {
+        initializeKey();
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+
+    public String getJwtFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring("Bearer ".length());
+        }
+        return null;
+    }
+
+    public boolean validateJwtToken(String token) {
+        try {
+            initializeKey();
+            Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/uni/backend/service/AuthService.java
+++ b/src/main/java/uni/backend/service/AuthService.java
@@ -1,0 +1,74 @@
+package uni.backend.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import uni.backend.domain.RefreshToken;
+import uni.backend.domain.Role;
+import uni.backend.domain.User;
+import uni.backend.domain.dto.LoginRequest;
+import uni.backend.domain.dto.LoginResponse;
+import uni.backend.domain.dto.MeResponse;
+import uni.backend.security.JwtUtils;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final AuthenticationManager authenticationManager;
+    private final JwtUtils jwtUtils;
+    private final RefreshTokenService refreshTokenService;
+
+    public LoginResponse login(LoginRequest loginRequest) {
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(loginRequest.getEmail(), loginRequest.getPassword())
+        );
+        User user = (User) authentication.getPrincipal();
+        String accessToken = jwtUtils.generateJwtToken(user.getEmail(), user.getRole());
+        String refreshToken = refreshTokenService.createRefreshToken(user.getUserId()).getToken();
+        return new LoginResponse(
+                "success", "logged in successfully", user.getName(),
+                user.getUserId(), user.getRole() == Role.KOREAN,
+                user.getProfile().getImgProf(), user.getProfile().getImgBack(),
+                accessToken, refreshToken
+        );
+    }
+
+    public Map<String, String> refreshAccessToken(String refreshToken) {
+        // RefreshToken 검증
+        RefreshToken token = refreshTokenService.verifyRefreshToken(refreshToken);
+
+        // 새 AccessToken 생성
+        String newAccessToken = jwtUtils.generateJwtToken(token.getUser().getEmail());
+
+        // 응답 데이터 반환
+        return Map.of(
+                "accessToken", newAccessToken,
+                "refreshToken", token.getToken()
+        );
+    }
+
+    public void logout(String token) {
+        if (token != null) {
+            refreshTokenService.deleteByToken(token);
+        }
+    }
+
+    public MeResponse getLoggedInUserInfo(User user) {
+        if (user == null) {
+            throw new IllegalStateException("User is not logged in.");
+        }
+
+        return MeResponse.builder()
+                .userId(user.getUserId())
+                .name(user.getName())
+                .role(user.getRole())
+                .imgProf(user.getProfile().getImgProf())
+                .build();
+    }
+}
+

--- a/src/main/java/uni/backend/service/RefreshTokenService.java
+++ b/src/main/java/uni/backend/service/RefreshTokenService.java
@@ -1,0 +1,68 @@
+package uni.backend.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import uni.backend.domain.RefreshToken;
+import uni.backend.domain.User;
+import uni.backend.repository.RefreshTokenRepository;
+import uni.backend.repository.UserRepository;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    @Value("${jwt.refreshExpirationMs}")
+    private Long refreshTokenExpirationMs;
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final UserRepository userRepository;
+
+    public RefreshToken createRefreshToken(Integer userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setUser(user);
+        refreshToken.setToken(UUID.randomUUID().toString());
+        refreshToken.setExpiresAt(Instant.now().plusMillis(refreshTokenExpirationMs));
+        refreshToken.setRevoked(false);
+
+        return refreshTokenRepository.save(refreshToken);
+    }
+
+    public RefreshToken verifyRefreshToken(String token) {
+        RefreshToken refreshToken = refreshTokenRepository.findByToken(token)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid refresh token"));
+
+        if (refreshToken.getExpiresAt().isBefore(Instant.now())) {
+            refreshToken.setRevoked(true);
+            refreshTokenRepository.save(refreshToken);
+            throw new IllegalArgumentException("Refresh token has expired");
+        }
+
+        if (refreshToken.isRevoked()) {
+            throw new IllegalArgumentException("Refresh token is revoked");
+        }
+
+        return refreshToken;
+    }
+
+    public void deleteByToken(String token) {
+        RefreshToken refreshToken = refreshTokenRepository.findByToken(token)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid refresh token"));
+        refreshTokenRepository.delete(refreshToken); // DB에서 토큰 삭제
+    }
+
+    @Transactional
+    @Scheduled(cron = "0 0 3 * * ?") // 매일 새벽 3시에 실행
+    public void removeExpiredTokens() {
+        refreshTokenRepository.deleteAllByExpiresAtBefore(Instant.now());
+    }
+}

--- a/src/main/java/uni/backend/service/UserService.java
+++ b/src/main/java/uni/backend/service/UserService.java
@@ -15,7 +15,7 @@ public interface UserService extends UserDetailsService {
 
     void generateAndSendResetCode(String email);
 
-    boolean verifyResetCode(String email, String code);
+    boolean verifyResetCode(String email, String token);
 
     void resetPassword(String email, String newPassword);
 }

--- a/src/main/java/uni/backend/service/UserServiceImpl.java
+++ b/src/main/java/uni/backend/service/UserServiceImpl.java
@@ -16,6 +16,7 @@ import uni.backend.domain.UserStatus;
 import uni.backend.domain.dto.MeResponse;
 import uni.backend.exception.UserStatusException;
 import uni.backend.repository.UserRepository;
+import uni.backend.security.JwtUtils;
 
 import java.util.*;
 
@@ -26,7 +27,7 @@ public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
     private final JavaMailSender mailSender;
-    private final Map<String, String> resetCodes = new HashMap<>();
+    private final JwtUtils jwtUtils;
 
     @Override
     @Transactional
@@ -40,7 +41,7 @@ public class UserServiceImpl implements UserService {
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         User user = userRepository.findByEmail(email)
-            .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
 
         if (user.getStatus() == UserStatus.BANNED) {
             log.warn("Banned user {} tried to log in", user.getEmail());
@@ -57,48 +58,56 @@ public class UserServiceImpl implements UserService {
             throw new IllegalArgumentException("No user found with email: " + email);
         }
 
-        String code = String.format("%06d", new Random().nextInt(999999));
-        resetCodes.put(email, code);
+        String resetToken = jwtUtils.generateJwtToken(email);
 
         SimpleMailMessage message = new SimpleMailMessage();
         message.setFrom("UNI <jdragon@uni-ajou.site>");
         message.setTo(email);
-        message.setSubject("Password Reset Code");
-        message.setText("Your password reset code is: " + code);
+        message.setSubject("Password Reset Token");
+        message.setText("Your password reset token is: " + resetToken);
         mailSender.send(message);
     }
 
     @Override
-    public boolean verifyResetCode(String email, String code) {
-        return resetCodes.containsKey(email) && resetCodes.get(email).equals(code);
+    public boolean verifyResetCode(String email, String token) {
+        try {
+            String tokenEmail = jwtUtils.getEmailFromJwtToken(token);
+            return email.equals(tokenEmail) && userRepository.findByEmail(email).isPresent();
+        } catch (Exception e) {
+            log.error("Invalid reset token or email mismatch: {}", e.getMessage());
+            return false;
+        }
     }
 
     @Override
-    public void resetPassword(String email, String newPassword) {
-        Optional<User> userOptional = userRepository.findByEmail(email);
-        if (userOptional.isEmpty()) {
-            throw new IllegalArgumentException("No user found with email: " + email);
+    public void resetPassword(String token, String newPassword) {
+        String email;
+        try {
+            email = jwtUtils.getEmailFromJwtToken(token);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid reset token.", e);
         }
 
-        User user = userOptional.get();
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("No user found with email: " + email));
+
         user.setPassword(new BCryptPasswordEncoder().encode(newPassword));
         userRepository.save(user);
-        resetCodes.remove(email);
     }
 
     public MeResponse getCurrentUserProfile() {
-        // SecurityContext에서 현재 사용자 가져오기
+        // SecurityContext 에서 현재 사용자 가져오기
         String currentUserEmail = SecurityContextHolder.getContext().getAuthentication().getName();
         User currentUser = userRepository.findByEmail(currentUserEmail)
-            .orElseThrow(() -> new IllegalArgumentException("로그인된 사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("로그인된 사용자를 찾을 수 없습니다."));
 
         return MeResponse.builder()
-            .userId(currentUser.getUserId())
-            .name(currentUser.getName())
-            .role(currentUser.getRole())
-            .imgProf(
-                currentUser.getProfile() != null ? currentUser.getProfile().getImgProf() : null)
-            .build();
+                .userId(currentUser.getUserId())
+                .name(currentUser.getName())
+                .role(currentUser.getRole())
+                .imgProf(
+                        currentUser.getProfile() != null ? currentUser.getProfile().getImgProf() : null)
+                .build();
     }
 
 
@@ -110,6 +119,6 @@ public class UserServiceImpl implements UserService {
     @Override
     public User findById(Integer userId) {
         return userRepository.findById(userId)
-            .orElseThrow(() -> new IllegalArgumentException("해당 ID의 사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("해당 ID의 사용자를 찾을 수 없습니다."));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,24 +11,25 @@ spring:
     properties:
       hibernate.dialect: org.hibernate.dialect.MySQL8Dialect
 
-  server:
-    servlet:
-      session:
-        timeout: 30m  # 세션 타임아웃을 30분으로 설정
-        cookie:
-          same-site: None
-          secure: false
-
-  logging:
-    level:
-      org.springframework.web.socket: DEBUG
-      org.springframework.messaging: DEBUG
-      org.springframework.security: DEBUG
-      org.springframework.web: DEBUG
-
-  profiles:
-    include: private
-
   servlet:
     multipart:
       enabled: true
+
+  profiles:
+    active: private
+
+server:
+  servlet:
+    session:
+      tracking-modes: cookie
+      cookie:
+        name: ''
+        same-site: none
+        secure: false
+
+logging:
+  level:
+    org.springframework.web.socket: DEBUG
+    org.springframework.messaging: DEBUG
+    org.springframework.security: DEBUG
+    org.springframework.web: DEBUG


### PR DESCRIPTION
#### 주요 변경 사항
1. **JWT 인증 방식 도입**:
   - 기존 세션 기반 인증을 JWT 토큰 기반 인증으로 변경.
   - 액세스 토큰 및 리프레시 토큰을 이용한 인증 및 갱신 로직 구현.

2. **리프레시 토큰 관리**:
   - 데이터베이스를 활용하여 리프레시 토큰 저장 및 만료/갱신 처리.
   - 서버 리부팅 시 만료된 리프레시 토큰 삭제 로직 추가 (`@Scheduled`).

4. **로그아웃 로직 수정**:
   - 서버에서 리프레시 토큰을 무효화하는 로직 구현.
   - 로그아웃 시 DB에 저장된 리프레시 토큰 삭제 처리.

#### 코드 구조 개선
- **JwtUtils**: 액세스 토큰 생성/검증 관련 로직을 집중화.
- **RefreshTokenService**: 리프레시 토큰 관련 관리 책임을 전담.
- 클라이언트와의 원활한 연동을 위한 HTTP 응답 형식 조정.

#### 테스트
- Postman을 사용하여 로그인/로그아웃 및 리프레시 토큰 갱신 테스트 완료.