### PR TITLE
110 채팅서비스 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,6 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'jakarta.servlet:jakarta.servlet-api:5.0.0'
 
-
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/uni/backend/config/ChatConfig.java
+++ b/src/main/java/uni/backend/config/ChatConfig.java
@@ -1,14 +1,20 @@
 package uni.backend.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import uni.backend.util.JwtChannelInterceptor;
 
 @Configuration
+@RequiredArgsConstructor
 @EnableWebSocketMessageBroker
 public class ChatConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final JwtChannelInterceptor jwtChannelInterceptor;
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
@@ -22,5 +28,10 @@ public class ChatConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         // WebSocket 엔드포인트 설정
         registry.addEndpoint("/ws/chat").setAllowedOriginPatterns("*").withSockJS();
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(jwtChannelInterceptor); //인터셉터 추가
     }
 }

--- a/src/main/java/uni/backend/controller/ChatController.java
+++ b/src/main/java/uni/backend/controller/ChatController.java
@@ -52,7 +52,7 @@ public class ChatController {
         if (messageRequest.getContent() == null || messageRequest.getContent().trim().isEmpty()) {
             return;
         }
-        ChatMessageResponse response = chatService.sendMessage(messageRequest, principal.getName(), null);
+        ChatMessageResponse response = chatService.sendMessage(messageRequest, principal.getName(), messageRequest.getRoomId());
 
         messagingTemplate.convertAndSend("/sub/chat/room/" + messageRequest.getRoomId(), response);
         messagingTemplate.convertAndSend("/sub/user/" + response.getReceiverId(), response);
@@ -82,30 +82,10 @@ public class ChatController {
         return ResponseEntity.ok(translation);
     }
 
-    //개별 메시지 읽음 처리
-    @MessageMapping("/read")
-    public void handleIncomingMessage(@Payload ChatMessageRequest messageRequest, Principal principal) {
-        ChatMessageResponse response = chatService.sendMessage(messageRequest, principal.getName(), null);
-
-        messagingTemplate.convertAndSend("/sub/chat/room/" + messageRequest.getRoomId(), response);
-
-        chatService.markMessageAsRead(response.getMessageId(), messageRequest.getRoomId(), principal.getName());
-    }
-
     //특정 채팅방 메시지 읽음 처리
     @MessageMapping("/enter")
     public void markMessagesAsRead(@Payload Integer roomId, Principal principal) {
         chatService.markMessagesAsRead(roomId, principal.getName());
-    }
-
-    @PostMapping("/read/bulk")
-    public ResponseEntity<String> handleBulkRead(@RequestBody ReadMessagesRequest request, Principal principal) {
-        try {
-            chatService.markMessagesAsRead(request.getRoomId(), request.getMessageIds(), principal.getName());
-            return ResponseEntity.ok("Messages marked as read.");
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Failed to mark messages as read.");
-        }
     }
 
     @PostMapping("/room/{roomId}/leave")

--- a/src/main/java/uni/backend/service/ChatService.java
+++ b/src/main/java/uni/backend/service/ChatService.java
@@ -88,6 +88,12 @@ public class ChatService {
                 .filter(msg -> !msg.isRead() && msg.getReceiver().equals(receiver))
                 .collect(Collectors.toList());
 
+        // 빈 리스트일 경우 saveAll 호출 생략
+        if (!unreadMessages.isEmpty()) {
+            unreadMessages.forEach(msg -> msg.setRead(true));
+            chatMessageRepository.saveAll(unreadMessages);
+        }
+
         unreadMessages.forEach(msg -> msg.setRead(true));
 
         if (chatRoom.getSender().equals(receiver)) {
@@ -96,7 +102,7 @@ public class ChatService {
             chatRoom.setReceiverUnreadCount(0);
         }
 
-        chatMessageRepository.saveAll(unreadMessages);
+        chatRoomRepository.save(chatRoom);
     }
 
     // 채팅방 조회
@@ -176,6 +182,7 @@ public class ChatService {
         long unreadCount = messages.stream()
                 .filter(msg -> !msg.isRead() && msg.getReceiver().equals(currentUser))
                 .count();
+
         if (chatRoom.getSender().equals(currentUser)) {
             chatRoom.setSenderUnreadCount(unreadCount);
         } else if (chatRoom.getReceiver().equals(currentUser)) {

--- a/src/main/java/uni/backend/service/ChatService.java
+++ b/src/main/java/uni/backend/service/ChatService.java
@@ -78,20 +78,6 @@ public class ChatService {
         return toChatMessageResponse(message);
     }
 
-    //개별 메시지 읽음 처리
-    @Transactional
-    public void markMessageAsRead(Integer messageId, Integer roomId, String username) {
-        ChatMessage message = chatMessageRepository.findById(messageId)
-                .orElseThrow(() -> new IllegalArgumentException("Message not found"));
-
-        if (!message.getReceiver().getEmail().equals(username)) {
-            throw new IllegalArgumentException("Only the receiver can mark the message as read");
-        }
-
-        message.setRead(true);
-        chatMessageRepository.save(message);
-    }
-
     //특정 채팅방 메시지 읽음 처리
     @Transactional
     public void markMessagesAsRead(Integer roomId, String username) {
@@ -111,20 +97,6 @@ public class ChatService {
         }
 
         chatMessageRepository.saveAll(unreadMessages);
-    }
-
-    @Transactional
-    public void markMessagesAsRead(Integer roomId, List<Integer> messageIds, String userEmail) {
-        // 메시지 ID 목록을 기반으로 읽음 상태 업데이트
-        List<ChatMessage> messagesToMarkAsRead = chatMessageRepository.findAllById(messageIds);
-
-        for (ChatMessage message : messagesToMarkAsRead) {
-            if (message.getChatRoom().getChatRoomId().equals(roomId) && message.getReceiver().getEmail().equals(userEmail)) {
-                message.setRead(true);
-            }
-        }
-
-        chatMessageRepository.saveAll(messagesToMarkAsRead);
     }
 
     // 채팅방 조회
@@ -210,8 +182,6 @@ public class ChatService {
             chatRoom.setReceiverUnreadCount(unreadCount);
         }
 
-        chatRoomRepository.save(chatRoom);
-
         return ChatRoomResponse.builder()
                 .chatRoomId(chatRoom.getChatRoomId())
                 .chatMessages(getChatMessages(chatRoom.getChatRoomId()))
@@ -236,24 +206,29 @@ public class ChatService {
                 .build();
     }
 
-    @Scheduled(fixedRate = 60000, initialDelay = 3000) //초기 시간 3초, 대기시간 120초
+    @Scheduled(cron = "0 0 0 * * *")
     public void notifyUnreadMessages() {
         List<ChatRoom> chatRooms = chatRoomRepository.findAll();
 
         for (ChatRoom chatRoom : chatRooms) {
+            LocalDateTime now = LocalDateTime.now();
+
+            // Sender 가 읽지 않은 메시지가 있고, 마지막 메시지가 1일 이상 지난 경우
             if (chatRoom.getSenderUnreadCount() > 0 &&
-                    chatRoom.getReceiverLastMessageAt() != null) {
+                    chatRoom.getReceiverLastMessageAt() != null &&
+                    chatRoom.getReceiverLastMessageAt().isBefore(now.minusDays(1))) {
                 sendUnreadMessageNotification(chatRoom.getSender().getEmail());
             }
+            // Receiver 가 읽지 않은 메시지가 있고, 마지막 메시지가 1일 이상 지난 경우
             if (chatRoom.getReceiverUnreadCount() > 0 &&
-                    chatRoom.getSenderLastMessageAt() != null) {
+                    chatRoom.getSenderLastMessageAt() != null &&
+                    chatRoom.getSenderLastMessageAt().isBefore(now.minusDays(1))) {
                 sendUnreadMessageNotification(chatRoom.getReceiver().getEmail());
             }
         }
     }
 
     private void sendUnreadMessageNotification(String email) {
-        // UserStatusScheduler로 이메일 전송 위임
         userStatusScheduler.sendEmailNotification(email, "읽지 않은 메시지가 있습니다.");
     }
 

--- a/src/main/java/uni/backend/service/RefreshTokenService.java
+++ b/src/main/java/uni/backend/service/RefreshTokenService.java
@@ -1,5 +1,6 @@
 package uni.backend.service;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -18,6 +19,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class RefreshTokenService {
 
+    @Getter
     @Value("${jwt.refreshExpirationMs}")
     private Long refreshTokenExpirationMs;
 
@@ -25,6 +27,10 @@ public class RefreshTokenService {
     private final UserRepository userRepository;
 
     public RefreshToken createRefreshToken(Integer userId) {
+        if (refreshTokenExpirationMs == null) {
+            throw new IllegalStateException("refreshTokenExpirationMs is not initialized");
+        }
+
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found"));
 

--- a/src/main/java/uni/backend/util/JwtChannelInterceptor.java
+++ b/src/main/java/uni/backend/util/JwtChannelInterceptor.java
@@ -1,0 +1,45 @@
+package uni.backend.util;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Component;
+import uni.backend.security.JwtUtils;
+
+import java.util.Collections;
+
+@Component
+@RequiredArgsConstructor
+public class JwtChannelInterceptor implements ChannelInterceptor {
+
+    private final JwtUtils jwtUtils;
+
+    @Override
+    public Message<?> preSend(@NonNull Message<?> message, @NonNull MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+        if (accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) {
+            // 헤더에서 JWT 토큰 추출
+            String token = accessor.getFirstNativeHeader("Authorization");
+            if (token != null && token.startsWith("Bearer ")) {
+                token = token.substring(7); // "Bearer " 제거
+                if (jwtUtils.validateJwtToken(token)) {
+                    String username = jwtUtils.getEmailFromJwtToken(token);
+                    UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                            username, null, Collections.emptyList());
+                    accessor.setUser(auth); // 인증된 사용자 설정
+                } else {
+                    throw new IllegalArgumentException("Invalid token");
+                }
+            } else {
+                throw new IllegalArgumentException("Authorization header missing or malformed");
+            }
+        }
+        return message;
+    }
+}

--- a/src/test/java/uni/backend/config/TestSecurityConfig.java
+++ b/src/test/java/uni/backend/config/TestSecurityConfig.java
@@ -1,0 +1,22 @@
+package uni.backend.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@TestConfiguration
+public class TestSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .securityMatcher("/**") // 모든 URL 경로에 대해 필터 체인 활성화
+                .authorizeHttpRequests(authorize -> authorize
+                        .anyRequest().permitAll() // 모든 요청 허용
+                )
+                .csrf(csrf -> csrf.disable()); // CSRF 비활성화
+
+        return http.build();
+    }
+}

--- a/src/test/java/uni/backend/service/ChatServiceTest.java
+++ b/src/test/java/uni/backend/service/ChatServiceTest.java
@@ -5,8 +5,7 @@ import org.junit.jupiter.api.Test;
 import uni.backend.domain.ChatMessage;
 import uni.backend.domain.ChatRoom;
 import uni.backend.domain.User;
-import uni.backend.domain.dto.ChatMessageRequest;
-import uni.backend.domain.dto.ChatRoomRequest;
+import uni.backend.domain.dto.*;
 import uni.backend.repository.ChatMessageRepository;
 import uni.backend.repository.ChatRoomRepository;
 import uni.backend.repository.UserRepository;
@@ -24,13 +23,14 @@ class ChatServiceTest {
     private ChatRoomRepository chatRoomRepository;
     private ChatMessageRepository chatMessageRepository;
     private UserRepository userRepository;
+    private TranslationService translationService;
 
     @BeforeEach
     void setUp() {
         chatRoomRepository = mock(ChatRoomRepository.class);
         chatMessageRepository = mock(ChatMessageRepository.class);
         userRepository = mock(UserRepository.class);
-        var translationService = mock(TranslationService.class);
+        translationService = mock(TranslationService.class); // 필드에 직접 할당
         var userStatusScheduler = mock(UserStatusScheduler.class);
 
         chatService = new ChatService(
@@ -81,13 +81,118 @@ class ChatServiceTest {
     }
 
     @Test
-    void testSendMessage() {
+    void testSendMessageWithEmptyContent() {
         // given
-        var request = ChatMessageRequest.builder().roomId(1).content("Hello").build();
+        var request = ChatMessageRequest.builder().roomId(1).content("").build(); // 빈 content
+        var senderEmail = "sender@example.com";
+
+        // when & then
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            chatService.sendMessage(request, senderEmail, 1);
+        });
+
+        assertEquals("Message content cannot be null or empty", exception.getMessage());
+    }
+
+    @Test
+    void testSendMessageWithDirectRoomId() {
+        // given
+        var request = ChatMessageRequest.builder().roomId(null).content("Hello").build(); // RoomId는 null
+        var senderEmail = "sender@example.com";
+        Integer roomId = 5; // 명시적으로 roomId 설정
+        var sender = User.builder().userId(1).email(senderEmail).build();
+        var receiver = User.builder().userId(2).email("receiver@example.com").build();
+        var chatRoom = ChatRoom.builder()
+                .chatRoomId(roomId)
+                .sender(sender) // sender 설정
+                .receiver(receiver) // receiver 설정
+                .build();
+
+        var message = ChatMessage.builder()
+                .messageId(1)
+                .chatRoom(chatRoom)
+                .sender(sender)
+                .receiver(receiver)
+                .content("Hello")
+                .sendAt(LocalDateTime.now())
+                .isRead(false)
+                .build();
+
+        // Mock 설정
+        when(chatRoomRepository.findById(roomId)).thenReturn(Optional.of(chatRoom));
+        when(userRepository.findByEmail(senderEmail)).thenReturn(Optional.of(sender));
+        when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(message); // Mock 반환값 설정
+
+        // when
+        var response = chatService.sendMessage(request, senderEmail, roomId);
+
+        // then
+        assertNotNull(response); // 반환된 응답이 null이 아님을 확인
+        assertEquals("Hello", response.getContent()); // 반환된 메시지 내용 확인
+        verify(chatRoomRepository).findById(roomId); // roomId가 명시적으로 사용됨 확인
+    }
+
+    @Test
+    void testSendMessageWithRequestRoomId() {
+        // given
+        Integer requestRoomId = 10; // request에 포함된 RoomId
+        var request = ChatMessageRequest.builder().roomId(requestRoomId).content("Hello").build(); // RoomId는 요청에서 가져옴
+        var senderEmail = "sender@example.com";
+        Integer roomId = null; // 명시적으로 roomId가 null
+        var sender = User.builder().userId(1).email(senderEmail).name("Sender").build();
+        var receiver = User.builder().userId(2).email("receiver@example.com").name("Receiver").build();
+        var chatRoom = ChatRoom.builder()
+                .chatRoomId(requestRoomId)
+                .sender(sender) // sender 설정
+                .receiver(receiver) // receiver 설정
+                .build();
+
+        var message = ChatMessage.builder()
+                .messageId(1)
+                .chatRoom(chatRoom)
+                .sender(sender)
+                .receiver(receiver)
+                .content("Hello")
+                .sendAt(LocalDateTime.now())
+                .isRead(false)
+                .build();
+
+        // Mock 설정
+        when(chatRoomRepository.findById(requestRoomId)).thenReturn(Optional.of(chatRoom));
+        when(userRepository.findByEmail(senderEmail)).thenReturn(Optional.of(sender));
+        when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(message); // Mock 반환값 설정
+
+        // when
+        var response = chatService.sendMessage(request, senderEmail, roomId);
+
+        // then
+        assertNotNull(response); // 반환된 응답이 null이 아님을 확인
+        assertEquals("Hello", response.getContent()); // 반환된 메시지 내용 확인
+        verify(chatRoomRepository).findById(requestRoomId); // request.getRoomId()가 사용됨 확인
+    }
+
+    @Test
+    void testSendMessageWithNullContent() {
+        // given
+        var request = ChatMessageRequest.builder().roomId(1).content(null).build(); // null content
+        var senderEmail = "sender@example.com";
+
+        // when & then
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            chatService.sendMessage(request, senderEmail, 1);
+        });
+
+        assertEquals("Message content cannot be null or empty", exception.getMessage());
+    }
+
+    @Test
+    void testSendMessageSuccessfullySenderIsChatRoomSender() {
+        // given
+        var request = ChatMessageRequest.builder().roomId(1).content("Hello").build(); // 유효한 content
         var senderEmail = "sender@example.com";
         var sender = User.builder().userId(1).email(senderEmail).name("Sender").build();
         var receiver = User.builder().userId(2).email("receiver@example.com").name("Receiver").build();
-        var chatRoom = ChatRoom.builder().chatRoomId(1).sender(sender).receiver(receiver).build();
+        var chatRoom = ChatRoom.builder().chatRoomId(1).sender(sender).receiver(receiver).build(); // sender가 chatRoom의 sender
 
         when(userRepository.findByEmail(senderEmail)).thenReturn(Optional.of(sender));
         when(chatRoomRepository.findById(1)).thenReturn(Optional.of(chatRoom));
@@ -110,26 +215,108 @@ class ChatServiceTest {
         // then
         assertNotNull(response);
         assertEquals("Hello", response.getContent());
+
+        // Verify chatRoom update for sender as chatRoom sender
+        assertEquals(LocalDateTime.now().getMinute(), chatRoom.getSenderLastMessageAt().getMinute()); // senderLastMessageAt 갱신 확인
+        assertEquals(1, chatRoom.getReceiverUnreadCount()); // receiverUnreadCount가 1 증가했는지 확인
+
         verify(chatMessageRepository).save(any(ChatMessage.class));
-        verify(chatRoomRepository).save(chatRoom);
+        verify(chatRoomRepository).save(chatRoom); // chatRoom이 업데이트 되었는지 확인
     }
 
     @Test
-    void testMarkMessagesAsRead() {
+    void testSendMessageSuccessfullySenderIsChatRoomReceiver() {
+        // given
+        var request = ChatMessageRequest.builder().roomId(1).content("Hello").build(); // 유효한 content
+        var senderEmail = "sender@example.com";
+        var sender = User.builder().userId(1).email(senderEmail).name("Sender").build();
+        var receiver = User.builder().userId(2).email("receiver@example.com").name("Receiver").build();
+        var chatRoom = ChatRoom.builder().chatRoomId(1).sender(receiver).receiver(sender).build(); // sender가 chatRoom의 receiver
+
+        when(userRepository.findByEmail(senderEmail)).thenReturn(Optional.of(sender));
+        when(chatRoomRepository.findById(1)).thenReturn(Optional.of(chatRoom));
+
+        var message = ChatMessage.builder()
+                .messageId(1)
+                .chatRoom(chatRoom)
+                .sender(sender)
+                .receiver(receiver)
+                .content("Hello")
+                .sendAt(LocalDateTime.now())
+                .isRead(false)
+                .build();
+
+        when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(message);
+
+        // when
+        var response = chatService.sendMessage(request, senderEmail, 1);
+
+        // then
+        assertNotNull(response);
+        assertEquals("Hello", response.getContent());
+
+        // Verify chatRoom update for sender as chatRoom receiver
+        assertEquals(LocalDateTime.now().getMinute(), chatRoom.getReceiverLastMessageAt().getMinute()); // receiverLastMessageAt 갱신 확인
+        assertEquals(1, chatRoom.getSenderUnreadCount()); // senderUnreadCount가 1 증가했는지 확인
+
+        verify(chatMessageRepository).save(any(ChatMessage.class));
+        verify(chatRoomRepository).save(chatRoom); // chatRoom이 업데이트 되었는지 확인
+    }
+
+    @Test
+    void testMarkMessagesAsReadForSender() {
         // given
         var roomId = 1;
-        var username = "receiver@example.com";
+        var username = "receiver@example.com"; // sender 가 읽은 경우
+        var sender = User.builder().userId(1).email("sender@example.com").name("Sender").build();
         var receiver = User.builder().userId(2).email(username).name("Receiver").build();
         var chatRoom = ChatRoom.builder()
                 .chatRoomId(1)
-                .sender(User.builder().userId(1).email("sender@example.com").name("Sender").build())
+                .sender(sender)
                 .receiver(receiver)
                 .build();
 
         var message = ChatMessage.builder()
                 .messageId(1)
                 .chatRoom(chatRoom)
-                .sender(chatRoom.getSender())
+                .sender(receiver)
+                .receiver(sender)
+                .content("Hi")
+                .sendAt(LocalDateTime.now())
+                .isRead(false)
+                .build();
+
+        chatRoom.setChatMessages(List.of(message));
+
+        when(chatRoomRepository.findById(roomId)).thenReturn(Optional.of(chatRoom));
+        when(userRepository.findByEmail(username)).thenReturn(Optional.of(sender));
+
+        // when
+        chatService.markMessagesAsRead(roomId, username);
+
+        // then
+        assertTrue(message.isRead(), "The message should be marked as read");
+        assertEquals(0, chatRoom.getReceiverUnreadCount(), "The receiver's unread count should be 0 after reading the message");
+        verify(chatMessageRepository).saveAll(chatRoom.getChatMessages());
+    }
+
+    @Test
+    void testMarkMessagesAsReadForReceiver() {
+        // given
+        var roomId = 1;
+        var username = "receiver@example.com"; // receiver가 읽은 경우
+        var sender = User.builder().userId(1).email("sender@example.com").name("Sender").build();
+        var receiver = User.builder().userId(2).email(username).name("Receiver").build();
+        var chatRoom = ChatRoom.builder()
+                .chatRoomId(1)
+                .sender(sender)
+                .receiver(receiver)
+                .build();
+
+        var message = ChatMessage.builder()
+                .messageId(1)
+                .chatRoom(chatRoom)
+                .sender(sender)
                 .receiver(receiver)
                 .content("Hi")
                 .sendAt(LocalDateTime.now())
@@ -145,8 +332,336 @@ class ChatServiceTest {
         chatService.markMessagesAsRead(roomId, username);
 
         // then
-        assertTrue(message.isRead());
+        assertTrue(message.isRead(), "The message should be marked as read");
+        assertEquals(0, chatRoom.getReceiverUnreadCount(), "The receiver's unread count should be 0 after reading the message");
         verify(chatMessageRepository).saveAll(chatRoom.getChatMessages());
+    }
+
+    @Test
+    void testMarkMessagesAsRead_CaseNotReadAndWrongReceiver() {
+        // given
+        var roomId = 1;
+        var username = "receiver@example.com";
+        var sender = User.builder().userId(1).email("sender@example.com").build();
+        var receiver = User.builder().userId(2).email(username).build();
+        var otherReceiver = User.builder().userId(3).email("other@example.com").build();
+        var chatRoom = ChatRoom.builder().chatRoomId(roomId).sender(sender).receiver(receiver).build();
+
+        var message = ChatMessage.builder()
+                .chatRoom(chatRoom)
+                .receiver(otherReceiver) // 잘못된 receiver
+                .isRead(false) // 아직 읽지 않은 메시지
+                .build();
+
+        chatRoom.setChatMessages(List.of(message));
+        when(chatRoomRepository.findById(roomId)).thenReturn(Optional.of(chatRoom));
+        when(userRepository.findByEmail(username)).thenReturn(Optional.of(receiver));
+
+        // when
+        chatService.markMessagesAsRead(roomId, username);
+
+        // then
+        assertFalse(message.isRead(), "The message should remain unread as it is for a different receiver");
+        verify(chatMessageRepository, never()).saveAll(any()); // 저장 동작이 발생하지 않아야 함
+        verify(chatRoomRepository).save(chatRoom); // 채팅방은 저장될 수 있음
+    }
+
+    @Test
+    void testMarkMessagesAsRead_CaseAlreadyReadAndCorrectReceiver() {
+        // given
+        var roomId = 1;
+        var username = "receiver@example.com";
+        var sender = User.builder().userId(1).email("sender@example.com").build();
+        var receiver = User.builder().userId(2).email(username).build();
+        var chatRoom = ChatRoom.builder().chatRoomId(roomId).sender(sender).receiver(receiver).build();
+
+        var message = ChatMessage.builder()
+                .chatRoom(chatRoom)
+                .receiver(receiver) // 올바른 receiver
+                .isRead(true) // 이미 읽은 메시지
+                .build();
+
+        chatRoom.setChatMessages(List.of(message));
+        when(chatRoomRepository.findById(roomId)).thenReturn(Optional.of(chatRoom));
+        when(userRepository.findByEmail(username)).thenReturn(Optional.of(receiver));
+
+        // when
+        chatService.markMessagesAsRead(roomId, username);
+
+        // then
+        assertTrue(message.isRead(), "The message should remain read");
+        verify(chatMessageRepository, never()).saveAll(any()); // 저장 동작이 발생하지 않아야 함
+    }
+
+    @Test
+    void testTranslateMessage() {
+        // given
+        var messageId = 1;
+        var acceptLanguage = "en";
+        var originalMessage = "Hi";
+        var targetLanguage = "en";
+
+        var translationResponse = new TranslationResponse();
+        IndividualTranslationResponse translation = new IndividualTranslationResponse();
+        translation.setText("Hello");
+        translationResponse.setTranslations(List.of(translation));
+
+        // Mock the repository and services
+        when(chatMessageRepository.findById(messageId))
+                .thenReturn(Optional.of(ChatMessage.builder()
+                        .messageId(messageId)
+                        .content(originalMessage)
+                        .build()));
+        when(translationService.determineTargetLanguage(acceptLanguage)).thenReturn(targetLanguage);
+        when(translationService.translate(any(TranslationRequest.class))).thenReturn(translationResponse);
+
+        // when
+        String translatedMessage = chatService.translateMessage(messageId, acceptLanguage);
+
+        // then
+        assertNotNull(translatedMessage);
+        assertEquals("Hello", translatedMessage); // The translated message should be "Hello"
+    }
+
+    @Test
+    void testTranslateMessageWhenMessageNotFound() {
+        // given
+        Integer messageId = 1;
+        String acceptLanguage = "en"; // 영어로 번역 요청
+
+        // 메시지가 없는 경우를 Mock 설정
+        when(chatMessageRepository.findById(messageId)).thenReturn(Optional.empty());
+
+        // when & then
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            chatService.translateMessage(messageId, acceptLanguage);
+        });
+
+        assertEquals("Message with ID 1 not found", exception.getMessage());
+    }
+
+    @Test
+    void testTranslateMessageWhenTranslationFails() {
+        // given
+        Integer messageId = 1;
+        String acceptLanguage = "en";  // 영어로 번역 요청
+        String originalMessage = "안녕하세요";  // 원본 메시지
+
+        // Mock the translation service
+        var translationService = mock(TranslationService.class);
+        var chatRoomRepository = mock(ChatRoomRepository.class);
+        var chatMessageRepository = mock(ChatMessageRepository.class);
+        var userRepository = mock(UserRepository.class);
+        var userStatusScheduler = mock(UserStatusScheduler.class);
+        chatService = new ChatService(chatRoomRepository, chatMessageRepository, userRepository, translationService, userStatusScheduler);
+
+        // Mock the translation response (empty response)
+        TranslationResponse translationResponse = mock(TranslationResponse.class);
+        when(translationService.translate(any(TranslationRequest.class))).thenReturn(translationResponse);
+        when(translationResponse.getTranslations()).thenReturn(List.of());
+
+        // Mock the method to get the message by id
+        when(chatMessageRepository.findById(messageId)).thenReturn(Optional.of(ChatMessage.builder()
+                .messageId(messageId)
+                .content(originalMessage)
+                .build()));
+
+        // when
+        String result = chatService.translateMessage(messageId, acceptLanguage);
+
+        // then
+        assertNull(result);  // 번역이 실패했으므로 null을 반환해야 함
+    }
+
+    @Test
+    void testTranslateMessageWhenOriginalMessageIsNull() {
+        // given
+        Integer messageId = 1;
+        String acceptLanguage = "en";
+
+        // ChatService를 Spy로 생성
+        ChatService spyChatService = spy(chatService);
+
+        // Mock 설정: getMessageById가 null을 반환하도록 설정
+        doReturn(null).when(spyChatService).getMessageById(messageId);
+
+        // when
+        String result = spyChatService.translateMessage(messageId, acceptLanguage);
+
+        // then
+        assertNull(result); // 메시지가 null이므로 null 반환
+    }
+
+    @Test
+    void testGetChatRoomsForUser() {
+        // given
+        var email = "user@example.com";
+        var user = User.builder().userId(1).email(email).name("User").build();
+
+        var chatRoom1 = ChatRoom.builder()
+                .chatRoomId(1)
+                .sender(user)
+                .receiver(User.builder().userId(2).email("receiver1@example.com").name("Receiver1").build())
+                .build();
+
+        var chatRoom2 = ChatRoom.builder()
+                .chatRoomId(2)
+                .sender(user)
+                .receiver(User.builder().userId(3).email("receiver2@example.com").name("Receiver2").build())
+                .build();
+
+        // Mock 설정
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(chatRoomRepository.findBySenderOrReceiver(user, user))
+                .thenReturn(List.of(chatRoom1, chatRoom2));
+
+        // 추가 Mock 설정: findById
+        when(chatRoomRepository.findById(1)).thenReturn(Optional.of(chatRoom1));
+        when(chatRoomRepository.findById(2)).thenReturn(Optional.of(chatRoom2));
+
+        // when
+        var chatRooms = chatService.getChatRoomsForUser(email);
+
+        // then
+        assertNotNull(chatRooms);
+        assertEquals(2, chatRooms.size()); // 두 개의 채팅방이 반환되어야 함
+        assertEquals(1, chatRooms.get(0).getChatRoomId()); // 첫 번째 채팅방 ID는 1이어야 함
+        assertEquals(2, chatRooms.get(1).getChatRoomId()); // 두 번째 채팅방 ID는 2이어야 함
+
+        // Verify Mock 동작
+        verify(userRepository).findByEmail(email);
+        verify(chatRoomRepository).findBySenderOrReceiver(user, user);
+        verify(chatRoomRepository).findById(1); // chatRoom1에 대한 findById 호출 검증
+        verify(chatRoomRepository).findById(2); // chatRoom2에 대한 findById 호출 검증
+    }
+
+    @Test
+    void testGetChatRoomsForUser_WhenCurrentUserIsReceiver() {
+        // given
+        var currentUser = User.builder()
+                .userId(2)
+                .email("receiver@example.com")
+                .name("Receiver")
+                .build();
+
+        var sender = User.builder()
+                .userId(1)
+                .email("sender@example.com")
+                .name("Sender")
+                .build();
+
+        var chatRoom = ChatRoom.builder()
+                .chatRoomId(1)
+                .sender(sender)
+                .receiver(currentUser) // currentUser를 receiver로 설정
+                .receiverUnreadCount(5) // 초기 unreadCount 설정
+                .build();
+
+        var message1 = ChatMessage.builder()
+                .messageId(1)
+                .chatRoom(chatRoom)
+                .sender(sender)
+                .receiver(currentUser)
+                .isRead(false)
+                .content("Hello")
+                .build();
+
+        chatRoom.setChatMessages(List.of(message1));
+
+        // Mock 설정
+        when(userRepository.findByEmail(currentUser.getEmail())).thenReturn(Optional.of(currentUser));
+        when(chatRoomRepository.findBySenderOrReceiver(currentUser, currentUser)).thenReturn(List.of(chatRoom));
+        when(chatRoomRepository.findById(1)).thenReturn(Optional.of(chatRoom));
+        when(chatMessageRepository.findByChatRoom(chatRoom)).thenReturn(List.of(message1));
+
+        // when
+        var chatRooms = chatService.getChatRoomsForUser(currentUser.getEmail());
+
+        // then
+        assertNotNull(chatRooms);
+        assertEquals(1, chatRooms.size());
+        var response = chatRooms.get(0);
+        assertEquals(1, response.getChatRoomId());
+        assertEquals(1, response.getUnreadCount()); // UnreadCount 값 검증
+        assertEquals(currentUser.getUserId(), response.getMyId());
+        assertEquals(sender.getUserId(), response.getOtherId());
+
+        verify(chatRoomRepository).findBySenderOrReceiver(currentUser, currentUser);
+        verify(chatRoomRepository).findById(1);
+        verify(chatMessageRepository).findByChatRoom(chatRoom);
+    }
+
+    @Test
+    void testGetChatRoomsForUser_WithMessages() {
+        // given
+        var email = "user@example.com";
+        var user = User.builder().userId(1).email(email).name("User").build();
+
+        var receiver1 = User.builder().userId(2).email("receiver1@example.com").name("Receiver1").build();
+        var receiver2 = User.builder().userId(3).email("receiver2@example.com").name("Receiver2").build();
+
+        var chatRoom1 = ChatRoom.builder()
+                .chatRoomId(1)
+                .sender(user)
+                .receiver(receiver1)
+                .build();
+
+        var chatRoom2 = ChatRoom.builder()
+                .chatRoomId(2)
+                .sender(user)
+                .receiver(receiver2)
+                .build();
+
+        // 메시지 설정
+        var message1 = ChatMessage.builder()
+                .messageId(1)
+                .chatRoom(chatRoom1)
+                .sender(user)
+                .receiver(receiver1)
+                .content("Hello")
+                .sendAt(LocalDateTime.now())
+                .isRead(false)
+                .build();
+
+        var message2 = ChatMessage.builder()
+                .messageId(2)
+                .chatRoom(chatRoom2)
+                .sender(user)
+                .receiver(receiver2)
+                .content("Hi")
+                .sendAt(LocalDateTime.now())
+                .isRead(false)
+                .build();
+
+        chatRoom1.setChatMessages(List.of(message1)); // chatRoom1 메시지 추가
+        chatRoom2.setChatMessages(List.of(message2)); // chatRoom2 메시지 추가
+
+        // Mock 설정
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(chatRoomRepository.findBySenderOrReceiver(user, user)).thenReturn(List.of(chatRoom1, chatRoom2));
+        when(chatRoomRepository.findById(1)).thenReturn(Optional.of(chatRoom1));
+        when(chatRoomRepository.findById(2)).thenReturn(Optional.of(chatRoom2));
+        when(chatMessageRepository.findByChatRoom(chatRoom1)).thenReturn(List.of(message1));
+        when(chatMessageRepository.findByChatRoom(chatRoom2)).thenReturn(List.of(message2));
+
+        // when
+        var chatRooms = chatService.getChatRoomsForUser(email);
+
+        // then
+        assertNotNull(chatRooms);
+        assertEquals(2, chatRooms.size());
+        assertEquals(1, chatRooms.get(0).getChatRoomId());
+        assertEquals(2, chatRooms.get(1).getChatRoomId());
+        assertEquals("Hello", chatRooms.get(0).getChatMessages().get(0).getContent());
+        assertEquals("Hi", chatRooms.get(1).getChatMessages().get(0).getContent());
+
+        // Verify Mock 호출
+        verify(userRepository).findByEmail(email);
+        verify(chatRoomRepository).findBySenderOrReceiver(user, user);
+        verify(chatRoomRepository).findById(1);
+        verify(chatRoomRepository).findById(2);
+        verify(chatMessageRepository).findByChatRoom(chatRoom1);
+        verify(chatMessageRepository).findByChatRoom(chatRoom2);
     }
 
     @Test
@@ -179,5 +694,89 @@ class ChatServiceTest {
         assertNotNull(messages);
         assertEquals(1, messages.size());
         assertEquals("Hi", messages.getFirst().getContent());
+    }
+
+    @Test
+    void testNotifyUnreadMessages() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+
+        // Sender에게 알림을 보내야 하는 ChatRoom
+        User sender = User.builder().userId(1).email("sender@example.com").build();
+        User receiver = User.builder().userId(2).email("receiver@example.com").build();
+
+        ChatRoom chatRoomWithSenderNotification = ChatRoom.builder()
+                .chatRoomId(1)
+                .sender(sender)
+                .receiver(receiver)
+                .senderUnreadCount(5) // Sender가 읽지 않은 메시지가 있음
+                .receiverLastMessageAt(now.minusDays(2)) // 마지막 메시지가 1일 이상 지남
+                .build();
+
+        ChatRoom chatRoomWithoutNotification = ChatRoom.builder()
+                .chatRoomId(2)
+                .sender(sender)
+                .receiver(receiver)
+                .senderUnreadCount(0) // 읽지 않은 메시지가 없음
+                .receiverLastMessageAt(now.minusHours(12)) // 마지막 메시지가 1일 지나지 않음
+                .build();
+
+        when(chatRoomRepository.findAll())
+                .thenReturn(List.of(chatRoomWithSenderNotification, chatRoomWithoutNotification));
+
+        // ChatService의 notifyUnreadMessages를 실행
+        chatService.notifyUnreadMessages();
+
+        // Mocked repository가 호출되었는지 확인
+        verify(chatRoomRepository, times(1)).findAll();
+
+        // 알림이 필요한 조건만 검증
+        assertEquals(5, chatRoomWithSenderNotification.getSenderUnreadCount());
+        assertTrue(chatRoomWithSenderNotification.getReceiverLastMessageAt().isBefore(now.minusDays(1)));
+    }
+
+    @Test
+    void testNotifyUnreadMessages_WhenReceiverHasUnreadMessages() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+
+        User sender = User.builder().userId(1).email("sender@example.com").build();
+        User receiver = User.builder().userId(2).email("receiver@example.com").build();
+
+        // Receiver가 알림 조건을 충족하는 ChatRoom 생성
+        ChatRoom chatRoomWithReceiverNotification = ChatRoom.builder()
+                .chatRoomId(1)
+                .sender(sender)
+                .receiver(receiver)
+                .receiverUnreadCount(3) // 읽지 않은 메시지가 있음
+                .senderLastMessageAt(now.minusDays(2)) // 마지막 메시지가 1일 이상 지남
+                .build();
+
+        // 알림 조건을 충족하지 않는 ChatRoom 생성
+        ChatRoom chatRoomWithoutNotification = ChatRoom.builder()
+                .chatRoomId(2)
+                .sender(sender)
+                .receiver(receiver)
+                .receiverUnreadCount(0) // 읽지 않은 메시지가 없음
+                .senderLastMessageAt(now.minusHours(12)) // 마지막 메시지가 1일 지나지 않음
+                .build();
+
+        when(chatRoomRepository.findAll())
+                .thenReturn(List.of(chatRoomWithReceiverNotification, chatRoomWithoutNotification));
+
+        // when
+        chatService.notifyUnreadMessages();
+
+        // then
+        // Mocked repository가 호출되었는지 확인
+        verify(chatRoomRepository, times(1)).findAll();
+
+        // 알림 조건을 충족하는 데이터 검증
+        assertEquals(3, chatRoomWithReceiverNotification.getReceiverUnreadCount());
+        assertTrue(chatRoomWithReceiverNotification.getSenderLastMessageAt().isBefore(now.minusDays(1)));
+
+        // 알림 조건을 충족하지 않는 데이터 검증
+        assertEquals(0, chatRoomWithoutNotification.getReceiverUnreadCount());
+        assertTrue(chatRoomWithoutNotification.getSenderLastMessageAt().isAfter(now.minusDays(1)));
     }
 }

--- a/src/test/java/uni/backend/service/RefreshTokenServiceTest.java
+++ b/src/test/java/uni/backend/service/RefreshTokenServiceTest.java
@@ -1,0 +1,179 @@
+package uni.backend.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+import uni.backend.domain.RefreshToken;
+import uni.backend.domain.User;
+import uni.backend.repository.RefreshTokenRepository;
+import uni.backend.repository.UserRepository;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ActiveProfiles("private")
+class RefreshTokenServiceTest {
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private RefreshTokenService refreshTokenService;
+
+    private final Long expirationMs = 604800000L;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        refreshTokenService = new RefreshTokenService(refreshTokenRepository, userRepository);
+
+        // refreshTokenExpirationMs 값 주입
+        ReflectionTestUtils.setField(refreshTokenService, "refreshTokenExpirationMs", expirationMs);
+    }
+
+    @Test
+    void createRefreshToken_ShouldThrowException_WhenExpirationMsNotInitialized() {
+        // given
+        Integer userId = 1;
+
+        // ReflectionTestUtils로 expirationMs를 null로 설정
+        ReflectionTestUtils.setField(refreshTokenService, "refreshTokenExpirationMs", null);
+
+        // when & then
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> refreshTokenService.createRefreshToken(userId),
+                "refreshTokenExpirationMs가 초기화되지 않았을 때 예외가 발생해야 합니다."
+        );
+
+        assertEquals("refreshTokenExpirationMs is not initialized", exception.getMessage());
+    }
+
+    @Test
+    void createRefreshToken_ShouldReturnRefreshToken() {
+        // given
+        Integer userId = 1;
+        User user = new User();
+        user.setUserId(userId);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(refreshTokenRepository.save(any(RefreshToken.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0)); // 저장된 객체 그대로 반환
+
+        // when
+        RefreshToken refreshToken = refreshTokenService.createRefreshToken(userId);
+
+        // then
+        assertNotNull(refreshToken, "생성된 RefreshToken이 null이어선 안됩니다.");
+        assertEquals(userId, refreshToken.getUser().getUserId(), "RefreshToken에 저장된 User ID가 올바르지 않습니다.");
+    }
+
+    @Test
+    void createRefreshToken_ShouldThrowException_WhenUserNotFound() {
+        // given
+        Integer userId = 1;
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThrows(UsernameNotFoundException.class, () -> refreshTokenService.createRefreshToken(userId));
+    }
+
+    @Test
+    void verifyRefreshToken_ShouldReturnToken_WhenValid() {
+        // given
+        String token = UUID.randomUUID().toString();
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setToken(token);
+        refreshToken.setExpiresAt(Instant.now().plusSeconds(3600));
+        refreshToken.setRevoked(false);
+
+        when(refreshTokenRepository.findByToken(token)).thenReturn(Optional.of(refreshToken));
+
+        // when
+        RefreshToken result = refreshTokenService.verifyRefreshToken(token);
+
+        // then
+        assertNotNull(result);
+        assertEquals(token, result.getToken());
+        verify(refreshTokenRepository, never()).save(refreshToken);
+    }
+
+    @Test
+    void verifyRefreshToken_ShouldThrowException_WhenTokenExpired() {
+        // given
+        String token = UUID.randomUUID().toString();
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setToken(token);
+        refreshToken.setExpiresAt(Instant.now().minusSeconds(3600));
+        refreshToken.setRevoked(false);
+
+        when(refreshTokenRepository.findByToken(token)).thenReturn(Optional.of(refreshToken));
+
+        // when & then
+        assertThrows(IllegalArgumentException.class, () -> refreshTokenService.verifyRefreshToken(token));
+        assertTrue(refreshToken.isRevoked());
+        verify(refreshTokenRepository, times(1)).save(refreshToken);
+    }
+
+    @Test
+    void verifyRefreshToken_ShouldThrowException_WhenTokenRevoked() {
+        // given
+        String token = UUID.randomUUID().toString();
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setToken(token);
+        refreshToken.setExpiresAt(Instant.now().plusSeconds(3600));
+        refreshToken.setRevoked(true);
+
+        when(refreshTokenRepository.findByToken(token)).thenReturn(Optional.of(refreshToken));
+
+        // when & then
+        assertThrows(IllegalArgumentException.class, () -> refreshTokenService.verifyRefreshToken(token));
+    }
+
+    @Test
+    void deleteByToken_ShouldDeleteToken() {
+        // given
+        String token = UUID.randomUUID().toString();
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setToken(token);
+
+        when(refreshTokenRepository.findByToken(token)).thenReturn(Optional.of(refreshToken));
+
+        // when
+        refreshTokenService.deleteByToken(token);
+
+        // then
+        verify(refreshTokenRepository, times(1)).delete(refreshToken);
+    }
+
+    @Test
+    void deleteByToken_ShouldThrowException_WhenTokenNotFound() {
+        // given
+        String token = UUID.randomUUID().toString();
+        when(refreshTokenRepository.findByToken(token)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThrows(IllegalArgumentException.class, () -> refreshTokenService.deleteByToken(token));
+    }
+
+    @Test
+    void removeExpiredTokens_ShouldDeleteExpiredTokens() {
+        // when
+        refreshTokenService.removeExpiredTokens();
+
+        // then
+        verify(refreshTokenRepository, times(1)).deleteAllByExpiresAtBefore(any(Instant.class));
+    }
+}


### PR DESCRIPTION
1. **WebSocket 인증 로직 수정**:
   - 기존 세션 기반 인증 방식을 JWT 기반 인증으로 변경.
   - WebSocket 연결 요청 시 `ChannelInterceptor`를 통해 JWT 토큰 검증.

2. **JWT 토큰 연동**:
   - 클라이언트의 WebSocket 연결 요청 헤더에 JWT 토큰을 포함하도록 구현.
   - `Principal` 객체에 사용자 정보를 담아 이후 메시지 처리 시 활용 가능.

3. **채팅 컨트롤러 수정**:
   - `Principal` 객체를 통해 현재 인증된 사용자의 정보를 가져오도록 변경.
   - 채팅 메시지 전송 및 수신 로직은 기존 방식 유지.

#### 클라이언트 연동 (UNI-frontend)
- 클라이언트에서 WebSocket 연결 시 JWT 토큰을 헤더에 포함하도록 수정:
  ```javascript
  stompClient.connect(
      { Authorization: `Bearer ${accessToken}` },
      onConnect,
      onError
  );
  ```

#### 테스트
- 채팅 메시지 전송 및 수신 기능 정상 작동 확인.

---

4. **테스트 코드 작성 및 기존 테스트 개선**

#### 작업 내용
- 주요 서비스 및 도메인 클래스에 대한 유닛 테스트 코드 작성
  - ChatService의 createChatRoom 메서드 테스트 추가
  - chatRoomRepository 및 userRepository 관련 Mock 설정 보완
- 테스트 시나리오에 맞는 Mock 데이터 생성 및 동작 검증
  - chatRoomRepository.findById, findBySenderAndReceiver 등에 필요한 Mock 설정 추가
  - save 호출 횟수 검증 로직 추가
- 기존 테스트 코드의 불필요한 중복 호출 제거 및 리팩토링
  - toChatRoomResponse 메서드에서 불필요한 save 호출 제거

#### 테스트 개선 사항
- IllegalArgumentException 발생 원인 분석 및 Mock 설정으로 해결
- Gradle 테스트 리포트 기반으로 실패 원인 점검 후 수정
- save, findById 등 호출 횟수와 동작 검증을 명확히 테스트 코드에 반영