### PR TITLE
[FEAT] 광고 관리 API 개발 및 개선

### DIFF
--- a/src/main/java/uni/backend/config/SecurityConfig.java
+++ b/src/main/java/uni/backend/config/SecurityConfig.java
@@ -33,15 +33,15 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-                .csrf(AbstractHttpConfigurer::disable)
-                .sessionManagement(session -> session
-                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/home", "/api/auth/**", "/ws/**").permitAll()
-                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
-                        .anyRequest().authenticated())
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+            .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+            .csrf(AbstractHttpConfigurer::disable)
+            .sessionManagement(session -> session
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/home", "/api/auth/**", "/ws/**").permitAll()
+                .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                .anyRequest().authenticated())
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/uni/backend/controller/AdController.java
+++ b/src/main/java/uni/backend/controller/AdController.java
@@ -1,54 +1,54 @@
 package uni.backend.controller;
 
-import java.util.List;
-import java.util.Objects;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import uni.backend.domain.Ad;
-import uni.backend.domain.dto.AdEditRequest;
 import uni.backend.domain.dto.AdListResponse;
 import uni.backend.domain.dto.AdRequest;
+import uni.backend.domain.dto.UpdateAdStatusRequest;
 import uni.backend.enums.AdStatus;
 import uni.backend.service.AdService;
 
 @RestController
-@RequestMapping("/api/admin/ad")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class AdController {
 
-    @Autowired
-    private AdService adService;
+    private final AdService adService;
 
-    private AdStatus extractStatus(String status) {
-        return AdStatus.POSTED;
-    }
-
-    @GetMapping()
+    // 모든 광고 조회
+    @GetMapping("/admin/ad")
     public ResponseEntity<AdListResponse> getAllAds() {
         AdListResponse adListResponse = adService.findAll();
         return ResponseEntity.ok(adListResponse);
     }
 
-    @PostMapping("/new")
-    public Ad createAd(
-        @RequestParam("userId") Integer userId,
-        @RequestParam("adImg") MultipartFile adImg,
-        @RequestBody AdRequest adRequest) {
+    // 새로운 광고 생성
+    @PostMapping("/admin/ad/new")
+    public ResponseEntity<Ad> createAd(
+        @RequestPart("adImg") MultipartFile adImg,
+        @RequestPart("adRequest") AdRequest adRequest) {
 
-        return adService.uploadAd(userId, adImg, adRequest);
+        Ad createdAd = adService.uploadAd(adImg, adRequest);
+        return ResponseEntity.ok(createdAd);
     }
 
-    @PostMapping()
-    public Ad updateAd(@RequestBody AdEditRequest adEditRequest) {
-        return adService.updateAdStatus(adEditRequest.getAdId(), adEditRequest.getAdStatus());
+
+    // 광고 상태 수정
+    @PostMapping("/admin/ad/update-status")
+    public ResponseEntity<Void> updateAdStatus(@RequestBody @Valid UpdateAdStatusRequest request) {
+        adService.updateAdStatus(request.getAdId(), request.getNewStatus());
+        return ResponseEntity.ok().build();
+    }
+
+
+    // 랜덤 ACTIVE 광고 반환
+    @GetMapping("/ad")
+    public ResponseEntity<Ad> getRandomActiveAd() {
+        Ad activeAd = adService.getRandomActiveAd();
+        return ResponseEntity.ok(activeAd);
     }
 }

--- a/src/main/java/uni/backend/domain/dto/AdListResponse.java
+++ b/src/main/java/uni/backend/domain/dto/AdListResponse.java
@@ -1,9 +1,11 @@
 package uni.backend.domain.dto;
 
 import java.util.List;
+import lombok.Builder;
 import lombok.Data;
 import uni.backend.domain.Ad;
 
+@Builder
 @Data
 public class AdListResponse {
 

--- a/src/main/java/uni/backend/domain/dto/AdRequest.java
+++ b/src/main/java/uni/backend/domain/dto/AdRequest.java
@@ -10,12 +10,13 @@ import uni.backend.enums.AdStatus;
 @Builder
 public class AdRequest {
 
-    String advertiser;
-    String title;
-    String adStatus;
-    LocalDate startDate;
-    LocalDate endDate;
-    String imageUrl;
+    private String advertiser;
+    private String title;
+    private AdStatus adStatus;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String imageUrl;
+
 }
 
 

--- a/src/main/java/uni/backend/domain/dto/AdResponse.java
+++ b/src/main/java/uni/backend/domain/dto/AdResponse.java
@@ -2,9 +2,11 @@ package uni.backend.domain.dto;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import lombok.Builder;
 import lombok.Data;
 import uni.backend.enums.AdStatus;
 
+@Builder
 @Data
 public class AdResponse {
 

--- a/src/main/java/uni/backend/domain/dto/UpdateAdStatusRequest.java
+++ b/src/main/java/uni/backend/domain/dto/UpdateAdStatusRequest.java
@@ -1,0 +1,13 @@
+package uni.backend.domain.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import uni.backend.enums.AdStatus;
+
+@Builder
+@Data
+public class UpdateAdStatusRequest {
+
+    private Integer adId;
+    private AdStatus newStatus;
+}

--- a/src/main/java/uni/backend/enums/AdStatus.java
+++ b/src/main/java/uni/backend/enums/AdStatus.java
@@ -1,7 +1,8 @@
 package uni.backend.enums;
 
 public enum AdStatus {
-    POSTED,
+    ACTIVE,
     ENDED,
+    INACTIVE,
     ERROR
 }

--- a/src/main/java/uni/backend/service/AdService.java
+++ b/src/main/java/uni/backend/service/AdService.java
@@ -1,18 +1,15 @@
 package uni.backend.service;
 
-
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
+import java.util.Random;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import uni.backend.domain.Ad;
-import uni.backend.domain.Profile;
 import uni.backend.domain.dto.AdListResponse;
 import uni.backend.domain.dto.AdRequest;
 import uni.backend.domain.dto.AdResponse;
@@ -24,78 +21,85 @@ import uni.backend.repository.AdRepository;
 @Slf4j
 public class AdService {
 
-    @Autowired
     private final AdRepository adRepository;
     private final AwsS3Service awsS3Service;
 
-//    public Ad uploadAd(AdRequest adRequest) {
-//        Ad ad = Ad.builder()
-//            .advertiser(adRequest.getAdvertiser())
-//            .title(adRequest.getTitle())
-//            .adStatus(
-//                Objects.equals(adRequest.getAdStatus(), "posted") ? AdStatus.POSTED
-//                    : AdStatus.ENDED)
-//            .startDate(adRequest.getStartDate())
-//            .endDate(adRequest.getEndDate())
-//            .imageUrl(adRequest.getImageUrl())
-//            .build();
-//        return adRepository.save(ad);
-//    }
-
+    // 특정 광고 조회
     public Ad findAdById(Integer id) {
-        return adRepository.findById(id).orElse(null);
+        return adRepository.findById(id).orElseThrow(() ->
+            new IllegalArgumentException("해당 ID의 광고가 존재하지 않습니다: " + id));
     }
 
-    public Ad updateAdStatus(Integer id, String status) {
-        Ad ad = findAdById(id);
-        ad.setAdStatus(status == "posted" ? AdStatus.POSTED : AdStatus.ENDED);
-        return adRepository.save(ad);
-    }
-
+    // 광고 삭제
+    @Transactional
     public void deleteAdById(Integer id) {
         Ad ad = findAdById(id);
         adRepository.delete(ad);
-        return;
     }
 
+    // 모든 광고 조회
     public AdListResponse findAll() {
         List<AdResponse> adResponses = adRepository.findAll().stream()
-            .map(ad -> {
-                AdResponse adResponse = new AdResponse();
-                adResponse.setAdId(ad.getAdId());
-                adResponse.setAdvertiser(ad.getAdvertiser());
-                adResponse.setTitle(ad.getTitle());
-                adResponse.setAdStatus(ad.getAdStatus() == AdStatus.POSTED ? "posted" : "ended");
-                adResponse.setStartDate(ad.getStartDate());
-                adResponse.setEndDate(ad.getEndDate());
-                adResponse.setImageUrl(ad.getImageUrl());
-                return adResponse;
-            })
+            .map(ad -> AdResponse.builder()
+                .adId(ad.getAdId())
+                .advertiser(ad.getAdvertiser())
+                .title(ad.getTitle())
+                .adStatus(ad.getAdStatus().name().toLowerCase())
+                .startDate(ad.getStartDate())
+                .endDate(ad.getEndDate())
+                .imageUrl(ad.getImageUrl())
+                .build())
             .collect(Collectors.toList());
 
-        AdListResponse adListResponse = new AdListResponse();
-        adListResponse.setAds(adResponses);
-        return adListResponse;
+        return AdListResponse.builder()
+            .ads(adResponses)
+            .build();
     }
 
-    public Ad uploadAd(Integer userId, MultipartFile adImg, AdRequest adRequest) {
+    // 광고 업로드
+    public Ad uploadAd(MultipartFile adImg, AdRequest adRequest) {
         if (adImg.isEmpty() || Objects.isNull(adImg.getOriginalFilename())) {
             throw new IllegalArgumentException("이미지가 비어 있거나 잘못된 파일입니다.");
         }
 
-        String imageUrl = awsS3Service.upload(adImg, "ads", userId);
+        // 광고 이미지를 S3에 업로드
+        String imageUrl = awsS3Service.uploadAdImage(adImg);
 
+        // 광고 객체 생성 및 저장
         Ad ad = Ad.builder()
             .advertiser(adRequest.getAdvertiser())
             .title(adRequest.getTitle())
-            .adStatus(
-                Objects.equals(adRequest.getAdStatus(), "posted") ? AdStatus.POSTED : AdStatus.ENDED
-            )
+            .adStatus(adRequest.getAdStatus())
             .startDate(adRequest.getStartDate())
             .endDate(adRequest.getEndDate())
             .imageUrl(imageUrl)
             .build();
 
         return adRepository.save(ad);
+    }
+
+
+    // 광고 상태 업데이트
+    @Transactional
+    public void updateAdStatus(Integer adId, AdStatus status) {
+        Ad ad = findAdById(adId);
+
+        log.info("광고 ID {}의 상태를 {}로 변경합니다.", adId, status);
+        ad.setAdStatus(status);
+        adRepository.save(ad);
+    }
+
+    // 랜덤 ACTIVE 광고 반환
+    public Ad getRandomActiveAd() {
+        List<Ad> activeAds = adRepository.findAll().stream()
+            .filter(ad -> ad.getAdStatus() == AdStatus.ACTIVE)
+            .collect(Collectors.toList());
+
+        if (activeAds.isEmpty()) {
+            throw new IllegalStateException("ACTIVE 상태의 광고가 없습니다.");
+        }
+
+        Random random = new Random();
+        return activeAds.get(random.nextInt(activeAds.size()));
     }
 }

--- a/src/main/java/uni/backend/util/AdminAccountUtil.java
+++ b/src/main/java/uni/backend/util/AdminAccountUtil.java
@@ -10,9 +10,11 @@ import org.springframework.mail.SimpleMailMessage;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import uni.backend.config.SecurityConfig;
+import uni.backend.domain.Profile;
 import uni.backend.domain.User;
 import uni.backend.domain.Role;
 import uni.backend.domain.UserStatus;
+import uni.backend.repository.UserRepository;
 
 @Component
 public class AdminAccountUtil {
@@ -40,11 +42,16 @@ public class AdminAccountUtil {
      */
     public User createAdminAccount(String rawPassword) {
         User admin = new User();
+        Profile profile = new Profile();
+        profile.setImgProf("/profile-image.png");
+        profile.setUser(admin);
+        
         admin.setEmail(createAdminName()); // 고유한 관리자 이메일 생성
         admin.setPassword(passwordEncoder.encode(rawPassword)); // 비밀번호 암호화 후 저장
         admin.setStatus(UserStatus.ACTIVE); // 활성화 상태 설정
         admin.setRole(Role.ADMIN); // 역할을 관리자(Admin)로 설정
         admin.setName("System Admin"); // 관리자 기본 이름 설정
+        admin.setProfile(profile);
         admin.setAdminId(UUID.randomUUID().toString()); // 고유 Admin ID 설정
         return admin;
     }


### PR DESCRIPTION
광고 생성, 조회, 상태 업데이트, 랜덤 활성 광고 반환 API를 구현했습니다.
- 광고 생성 API: 이미지와 광고 정보를 동시에 처리할 수 있도록 multipart/form-data 방식으로 구현.
- 광고 조회 API: 모든 광고를 반환하는 기능 추가.
- 광고 상태 업데이트 API: JSON 요청 본문을 처리하며 광고 상태를 변경할 수 있도록 개선.
- 랜덤 활성 광고 반환 API: ACTIVE 상태의 광고 중 하나를 랜덤으로 반환.