### PR TITLE
131 밴 당한 사람 프로필 전달 제외 및 관리자 신고 목록 조회시 신고 시간 전달하기

### DIFF
--- a/src/main/java/uni/backend/controller/AdminController.java
+++ b/src/main/java/uni/backend/controller/AdminController.java
@@ -83,7 +83,7 @@ public class AdminController {
      */
     @GetMapping("/reported-users")
     public ResponseEntity<Page<ReportedUserResponse>> getReportedUsers(
-        @RequestParam(defaultValue = "1") int page,
+        @RequestParam(defaultValue = "0") int page,
         @RequestParam(defaultValue = "10") int size) {
 
         Page<ReportedUserResponse> reportedUsers = adminService.getReportedUsers(page, size);

--- a/src/main/java/uni/backend/domain/dto/ReportedUserResponse.java
+++ b/src/main/java/uni/backend/domain/dto/ReportedUserResponse.java
@@ -1,5 +1,6 @@
 package uni.backend.domain.dto;
 
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -28,5 +29,6 @@ public class ReportedUserResponse {
         private String category;      // 신고 카테고리 (PROFILE, CHAT, QNA, REVIEW 등)
         private String reason;        // 신고 사유 (욕설/혐오/차별, 음란물 등)
         private String detailedReason; // 상세 신고 사유
+        private LocalDateTime reportedAt;
     }
 }

--- a/src/main/java/uni/backend/repository/ProfileRepository.java
+++ b/src/main/java/uni/backend/repository/ProfileRepository.java
@@ -30,7 +30,6 @@ public interface ProfileRepository extends JpaRepository<Profile, Integer> { // 
 
     Optional<Profile> findByUser(User user); // User 객체를 통해 Profile 조회
 
-    //    Remapper findByUnivNameAndHashtags(List<String> hashtags, int size, PageRequest pageable);
     @Query("SELECT DISTINCT p FROM Profile p " +
         "LEFT JOIN p.mainCategories mc " +
         "LEFT JOIN mc.hashtag h " +
@@ -41,7 +40,8 @@ public interface ProfileRepository extends JpaRepository<Profile, Integer> { // 
         " LEFT JOIN p2.mainCategories mc2 " +
         " LEFT JOIN mc2.hashtag h2 " +
         " WHERE p2.profileId = p.profileId AND h2.hashtagName IN :hashtags) = :hashtagsSize) " +
-        "AND p.user.role = 'KOREAN'")
+        "AND p.user.role = 'KOREAN' " +
+        "AND p.user.status <> 'BANNED'")
     Page<Profile> findByUnivNameAndHashtags(
         @Param("univName") String univName,
         @Param("hashtags") List<String> hashtags,

--- a/src/main/java/uni/backend/service/AdminService.java
+++ b/src/main/java/uni/backend/service/AdminService.java
@@ -164,7 +164,8 @@ public class AdminService {
                             report.getTitle(),
                             report.getCategory().name(),
                             report.getReason().name(),
-                            report.getDetailedReason()
+                            report.getDetailedReason(),
+                            report.getReportedAt()
                         ))
                         .collect(Collectors.toList())
                 );


### PR DESCRIPTION
[[FEAT] 프로필 밴 상태일 경우 노출 제외 및 신고 시간 응답에 추가]
- 프로필 조회 시, 밴 상태(BANNED)인 유저의 프로필이 결과에서 제외되도록 로직 수정
- 신고된 유저 목록 응답에 신고 시간(reportedAt) 추가
  - ReportedUserResponse DTO에 reportedAt 필드 추가
 [[FIX] 신고된 유저 목록 조회에서 default page 설정을 0으로 변경했습니다.]