### PR TITLE
[HOTFIX] '대학생활'로 공백없이 검색할 때에도 '대학 생활'이 검색되도록 변경

### DIFF
--- a/src/main/java/uni/backend/service/PageTranslationService.java
+++ b/src/main/java/uni/backend/service/PageTranslationService.java
@@ -3,6 +3,7 @@ package uni.backend.service;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -209,6 +210,9 @@ public class PageTranslationService {
 
     public String mapToForeignKeyword(String koreanKeyword, String targetLanguage) {
         String result = koreanKeyword;
+        if (Objects.equals(koreanKeyword, "대학생활")) {
+            koreanKeyword = "대학 생활";
+        }
         if (MainCategoryMap.KOREAN_HASHTAG_MAP.containsKey(koreanKeyword)) {
             Map<String, String> subMap = MainCategoryMap.KOREAN_HASHTAG_MAP.get(koreanKeyword);
             if (subMap.containsKey(targetLanguage)) {


### PR DESCRIPTION
Map이라서 공백이 구분 기준이 안되는지 `KOREAN_HASHTAG_MAP`에 "대학생활"과 "대학 생활" key를 동시에 넣을 수 없어서 `mapToForeignKeyword`에 하드코딩으로 추가하였습니다